### PR TITLE
Crash when clicking row headers

### DIFF
--- a/library/src/com/squareup/timessquare/CalendarRowView.java
+++ b/library/src/com/squareup/timessquare/CalendarRowView.java
@@ -67,7 +67,10 @@ public class CalendarRowView extends ViewGroup implements View.OnClickListener {
   }
 
   @Override public void onClick(View v) {
-    listener.handleClick((MonthCellDescriptor) v.getTag());
+    // Header rows don't have a click listener
+    if (listener != null) {
+      listener.handleClick((MonthCellDescriptor) v.getTag());
+    }
   }
 
   public void setListener(MonthView.Listener listener) {


### PR DESCRIPTION
Clicking a week row header (Mon, Tue, Wed, etc.) results in a crash because it has no MonthView.Listener.

Ideally, we want to avoid adding click listeners to the header row children in the first place.  CalendarRowView is inflated from XML and it adds all of its children (TextViews) before setIsRowHeader(true) is called, so we can't rely on that flag in addView().  We could add a custom XML attribute to declare it as a header row, in which case we could use that flag and avoid setting click listeners in addView().

For simplicity I have only performed a null check on the listener.

---

Sorry I wasn't able to run mvn clean verify prior to this pull request.  I'm encountering various errors resolving the build extensions.  I'll try to figure out how to fix this but if you have any ideas that would be very helpful.

$ mvn clean verify
[INFO] Scanning for projects...
Downloading: http://nexus.springpadapp.com:8081/nexus/content/groups/public/com/jayway/maven/plugins/android/generation2/android-maven-plugin/3.4.1/android-maven-plugin-3.4.1.pom
[ERROR] The build could not read 2 projects -> [Help 1]
[ERROR]  
[ERROR]   The project com.squareup:android-times-square:1.0.1-SNAPSHOT (/Users/jameswald/Development/tools/android/android-times-square/library/pom.xml) has 2 errors
[ERROR]     Unresolveable build extension: Plugin com.jayway.maven.plugins.android.generation2:android-maven-plugin:3.4.1 or one of its dependencies could not be resolved: Failed to collect dependencies for com.jayway.maven.plugins.android.generation2:android-maven-plugin:jar:3.4.1 (): Failed to read artifact descriptor for com.jayway.maven.plugins.android.generation2:android-maven-plugin:jar:3.4.1: Could not transfer artifact com.jayway.maven.plugins.android.generation2:android-maven-plugin:pom:3.4.1 from/to Nexus (http://nexus.springpadapp.com:8081/nexus/content/groups/public): Error transferring file: Connection refused -> [Help 2]
[ERROR]     Unknown packaging: apklib @ line 15, column 14
