### PR TITLE
Add listener to set selectability of arbitrary dates

### DIFF
--- a/library/test/com/squareup/timessquare/CalendarPickerViewTest.java
+++ b/library/test/com/squareup/timessquare/CalendarPickerViewTest.java
@@ -10,7 +10,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import com.squareup.timessquare.CalendarPickerView;
 import static java.util.Calendar.DAY_OF_MONTH;
+import static java.util.Calendar.DAY_OF_WEEK;
 import static java.util.Calendar.DECEMBER;
 import static java.util.Calendar.FEBRUARY;
 import static java.util.Calendar.JANUARY;
@@ -300,6 +302,24 @@ public class CalendarPickerViewTest {
     boolean wasAbleToSetDate = view.setSelectedDate(jumpToCal.getTime());
     assertThat(wasAbleToSetDate).isTrue();
     assertThat(view.selectedCells.get(0).isSelectable()).isTrue();
+  }
+
+  @Test
+  public void testOnDateConfiguredListener() {
+    final Calendar testCal = Calendar.getInstance();    
+    view.setOnDateConfiguredListener(new CalendarPickerView.OnDateConfiguredListener() {
+      @Override public boolean isDateSelectable(Date date) {
+        testCal.setTime(date);
+        int dayOfWeek = testCal.get(DAY_OF_WEEK);
+        return dayOfWeek > 1 && dayOfWeek < 7;
+      }
+    });
+    view.init(today.getTime(), minDate, maxDate);
+    Calendar jumpToCal = Calendar.getInstance();
+    jumpToCal.add(MONTH, 2);
+    jumpToCal.set(DAY_OF_WEEK, 1);
+    boolean wasAbleToSetDate = view.setSelectedDate(jumpToCal.getTime());
+    assertThat(wasAbleToSetDate).isFalse();
   }
 
   private static void assertCell(List<List<MonthCellDescriptor>> cells, int row, int col,


### PR DESCRIPTION
Fixes #32.

Some issues:
- `setOnDateConfiguredListener` must be called before `init`.
- The error message doesn't make sense, and shouldn't be hardcoded anyway. I suggest adding an `onInvalidDateSelected` method to `OnDateSelectedListener`, and getting rid of the Toast.

Some possible improvements: 
- Combine the various selectability tests done in three different places into one method.
- Allow selection by client code, but disallow user selection.
- Add `init` variations to take an `OnDateConfiguredListener`.
