### PR TITLE
Fix IllegalStateException when trying to add a header or footer to the CalendarPickerView on Samsung Galaxy Nexus running Android 4.2.2

### DIFF
--- a/library/src/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/com/squareup/timessquare/CalendarPickerView.java
@@ -73,7 +73,6 @@ public class CalendarPickerView extends ListView {
     adapter = new MonthAdapter();
     setDivider(null);
     setDividerHeight(0);
-    setAdapter(adapter);
     final int bg = getResources().getColor(R.color.calendar_bg);
     setBackgroundColor(bg);
     setCacheColorHint(bg);
@@ -140,6 +139,9 @@ public class CalendarPickerView extends ListView {
   }
 
   private void initialize(List<Date> selectedDates, Date minDate, Date maxDate) {
+    if (getAdapter() == null) {
+        setAdapter(adapter);
+    }
     if (selectionMode == SelectionMode.SINGLE && selectedDates.size() > 1) {
       throw new IllegalArgumentException("SINGLE mode cannot be used with multiple selectedDates");
     }


### PR DESCRIPTION
IllegalStateException...-- setAdapter has already been called when trying to add a header or a footer.

This crash occured on a Samsung Galaxy Nexus running 4.2.2 which is completely normal.
I removed the setAdapter from the constructor and moved it to the private initialize method and set the adapter only if the getAdapter method returns null.
This change enables the possibility to add header or footer to the CalendarPickerView.
