### PR TITLE
Allow fine-grained style overriding by client applications

### DIFF
--- a/library/res/color/calendar_bg_selector.xml
+++ b/library/res/color/calendar_bg_selector.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2012 Square, Inc. -->
 
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
+<selector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
   <item android:state_selected="true">
     <color android:color="@color/calendar_selected_day_bg"/>
   </item>
   <item android:state_pressed="true">
     <color android:color="@color/calendar_selected_day_bg"/>
   </item>
-  <item android:state_enabled="false">
+  <item app:state_current_month="false">
     <color android:color="@color/calendar_inactive_month_bg"/>
   </item>
-  <item android:state_checked="false">
+  <item app:state_today="true">
     <color android:color="@color/calendar_text_active"/>
   </item>
   <item>

--- a/library/res/color/calendar_text_selector.xml
+++ b/library/res/color/calendar_text_selector.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2012 Square, Inc. -->
 
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
+<selector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
   <item android:state_selected="true" android:color="@color/calendar_text_selected"/>
   <item android:state_pressed="true" android:color="@color/calendar_text_selected"/>
-  <item android:state_enabled="false" android:color="@color/calendar_text_inactive"/>
-  <item android:state_checked="false" android:color="@color/calendar_active_month_bg"/>
+  <item app:state_current_month="false" android:color="@color/calendar_text_inactive"/>
+  <item app:state_today="true" android:color="@color/calendar_active_month_bg"/>
+  <item app:state_selectable="false" android:color="@color/calendar_text_unselectable" />
   <item android:color="@color/calendar_text_active"/>
 </selector>

--- a/library/res/layout/week.xml
+++ b/library/res/layout/week.xml
@@ -5,37 +5,37 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     >
-  <CheckedTextView
+  <com.squareup.timessquare.CalendarCellView
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       style="@style/CalendarCell.CalendarDate"
       />
-  <CheckedTextView
+  <com.squareup.timessquare.CalendarCellView
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       style="@style/CalendarCell.CalendarDate"
       />
-  <CheckedTextView
+  <com.squareup.timessquare.CalendarCellView
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       style="@style/CalendarCell.CalendarDate"
       />
-  <CheckedTextView
+  <com.squareup.timessquare.CalendarCellView
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       style="@style/CalendarCell.CalendarDate"
       />
-  <CheckedTextView
+  <com.squareup.timessquare.CalendarCellView
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       style="@style/CalendarCell.CalendarDate"
       />
-  <CheckedTextView
+  <com.squareup.timessquare.CalendarCellView
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       style="@style/CalendarCell.CalendarDate"
       />
-  <CheckedTextView
+  <com.squareup.timessquare.CalendarCellView
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       style="@style/CalendarCell.CalendarDate"

--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <declare-styleable name="calendar_cell">
+    <attr name="state_selectable" format="boolean" />
+    <attr name="state_current_month" format="boolean" />
+    <attr name="state_today" format="boolean" />
+  </declare-styleable>
+</resources>

--- a/library/res/values/styles.xml
+++ b/library/res/values/styles.xml
@@ -21,6 +21,7 @@
   <style name="CalendarCell.CalendarDate">
     <item name="android:textSize">@dimen/calendar_text_medium</item>
     <item name="android:background">@color/calendar_bg_selector</item>
+    <item name="android:textColor">@color/calendar_text_selector</item>
     <item name="android:clickable">true</item>
     <item name="android:textStyle">bold</item>
   </style>

--- a/library/src/com/squareup/timessquare/CalendarCellView.java
+++ b/library/src/com/squareup/timessquare/CalendarCellView.java
@@ -1,0 +1,68 @@
+// Copyright 2013 Square, Inc.
+package com.squareup.timessquare;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.TextView;
+
+public class CalendarCellView extends TextView {
+
+  private static final int[] STATE_SELECTABLE = {
+      R.attr.state_selectable
+  };
+  private static final int[] STATE_CURRENT_MONTH = {
+      R.attr.state_current_month
+  };
+  private static final int[] STATE_TODAY = {
+      R.attr.state_today
+  };
+
+  private boolean isSelectable = false;
+  private boolean isCurrentMonth = false;
+  private boolean isToday = false;
+
+  public CalendarCellView(Context context) {
+    super(context);
+  }
+
+  public CalendarCellView(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  public CalendarCellView(Context context, AttributeSet attrs, int defStyle) {
+    super(context, attrs, defStyle);
+  }
+
+  public void setSelectable(boolean isSelectable) {
+    this.isSelectable = isSelectable;
+    refreshDrawableState();
+  }
+
+  public void setCurrentMonth(boolean isCurrentMonth) {
+    this.isCurrentMonth = isCurrentMonth;
+    refreshDrawableState();
+  }
+
+  public void setToday(boolean isToday) {
+    this.isToday = isToday;
+    refreshDrawableState();
+  }
+
+  @Override protected int[] onCreateDrawableState(int extraSpace) {
+    final int[] drawableState = super.onCreateDrawableState(extraSpace + 4);
+
+    if (isSelectable) {
+      mergeDrawableStates(drawableState, STATE_SELECTABLE);
+    }
+
+    if (isCurrentMonth) {
+      mergeDrawableStates(drawableState, STATE_CURRENT_MONTH);
+    }
+
+    if (isToday) {
+      mergeDrawableStates(drawableState, STATE_TODAY);
+    }
+
+    return drawableState;
+  }
+}

--- a/library/src/com/squareup/timessquare/MonthView.java
+++ b/library/src/com/squareup/timessquare/MonthView.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
-import android.widget.CheckedTextView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import java.text.DateFormat;
@@ -59,16 +58,15 @@ public class MonthView extends LinearLayout {
         List<MonthCellDescriptor> week = cells.get(i);
         for (int c = 0; c < week.size(); c++) {
           MonthCellDescriptor cell = week.get(c);
-          CheckedTextView cellView = (CheckedTextView) weekRow.getChildAt(c);
+          CalendarCellView cellView = (CalendarCellView) weekRow.getChildAt(c);
+
           cellView.setText(Integer.toString(cell.getValue()));
           cellView.setEnabled(cell.isCurrentMonth());
-          cellView.setChecked(!cell.isToday());
+
+          cellView.setSelectable(cell.isSelectable());
           cellView.setSelected(cell.isSelected());
-          if (cell.isSelectable()) {
-            cellView.setTextColor(getResources().getColorStateList(R.color.calendar_text_selector));
-          } else {
-            cellView.setTextColor(getResources().getColor(R.color.calendar_text_unselectable));
-          }
+          cellView.setCurrentMonth(cell.isCurrentMonth());
+          cellView.setToday(cell.isToday());
           cellView.setTag(cell);
         }
       } else {


### PR DESCRIPTION
Ran into a problem when styling the calendar: I needed a different text color for other-month dates and unselectable dates, but it was hardcoded in `MonthView`. I also found it really confusing to mentally map `state_enabled` to `!isCurrentMonth` and `state_checked` to `!isToday`.

This change replaces the use of `CheckedTextView` with custom `TextView` subclass that manages some more aptly-named cell states. Client applications can now set different styles based on any combination of these states, the state semantics are a lot easier to remember, we aren't hardcoding styles, and it will be much easier to add additional states in the future.
