### PR TITLE
Make "today" and selected days actually visible.

### DIFF
--- a/library/res/values/colors.xml
+++ b/library/res/values/colors.xml
@@ -1,6 +1,6 @@
 <!-- Copyright 2012 Square, Inc. -->
 <resources>
-  <color name="calendar_active_month_bg">#fff5f7f9</color>
+  <color name="calendar_active_month_bg">#ff000000</color>
   <color name="calendar_bg">#ffffffff</color>
   <color name="calendar_divider">#ffbababa</color>
   <color name="calendar_inactive_month_bg">#ffd7d9db</color>
@@ -8,6 +8,6 @@
   <color name="calendar_selected_period_bg">#ff96caff</color>
   <color name="calendar_text_inactive">#40778088</color>
   <color name="calendar_text_active">#ff778088</color>
-  <color name="calendar_text_selected">#ffffffff</color>
+  <color name="calendar_text_selected">#ff379bff</color>
   <color name="calendar_text_unselectable">#7f778088</color>
 </resources>


### PR DESCRIPTION
selected days were white as the background. "today"'s grey was also too bright. 

before:
![2013-05-24 23 25 57](https://f.cloud.github.com/assets/1377701/563708/3204bc50-c504-11e2-8d93-fadd89144890.png)

after:
![2013-05-24 23 29 58](https://f.cloud.github.com/assets/1377701/563713/901a4a08-c504-11e2-97a2-595a2386f28f.png)
