### PR TITLE
Allow highlighting calendar cells

### DIFF
--- a/library/res/drawable/calendar_bg_selector.xml
+++ b/library/res/drawable/calendar_bg_selector.xml
@@ -15,6 +15,9 @@
   <item app:state_current_month="false">
     <color android:color="@color/calendar_inactive_month_bg"/>
   </item>
+  <item app:state_highlighted="true">
+    <color android:color="@color/calendar_highlighted_day_bg"/>
+  </item>
   <item app:state_today="true">
     <color android:color="@color/calendar_text_active"/>
   </item>

--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -7,5 +7,6 @@
     <attr name="state_range_first" format="boolean" />
     <attr name="state_range_middle" format="boolean" />
     <attr name="state_range_last" format="boolean" />
+    <attr name="state_highlighted" format="boolean" />
   </declare-styleable>
 </resources>

--- a/library/res/values/colors.xml
+++ b/library/res/values/colors.xml
@@ -5,6 +5,7 @@
   <color name="calendar_divider">#ffbababa</color>
   <color name="calendar_inactive_month_bg">#ffd7d9db</color>
   <color name="calendar_selected_day_bg">#ff379bff</color>
+  <color name="calendar_highlighted_day_bg">#ccffcc</color>
   <color name="calendar_selected_range_bg">#ff96caff</color>
   <color name="calendar_text_inactive">#40778088</color>
   <color name="calendar_text_active">#ff778088</color>

--- a/library/src/com/squareup/timessquare/CalendarCellView.java
+++ b/library/src/com/squareup/timessquare/CalendarCellView.java
@@ -18,6 +18,9 @@ public class CalendarCellView extends TextView {
   private static final int[] STATE_TODAY = {
       R.attr.state_today
   };
+  private static final int[] STATE_HIGHLIGHTED = {
+      R.attr.state_highlighted
+  };
   private static final int[] STATE_RANGE_FIRST = {
       R.attr.state_range_first
   };
@@ -31,6 +34,7 @@ public class CalendarCellView extends TextView {
   private boolean isSelectable = false;
   private boolean isCurrentMonth = false;
   private boolean isToday = false;
+  private boolean isHighlighted = false;
   private RangeState rangeState = RangeState.NONE;
 
   public CalendarCellView(Context context) {
@@ -65,8 +69,12 @@ public class CalendarCellView extends TextView {
     refreshDrawableState();
   }
 
+  public void setHighlighted(boolean highlighted) {
+    isHighlighted = highlighted;
+  }
+
   @Override protected int[] onCreateDrawableState(int extraSpace) {
-    final int[] drawableState = super.onCreateDrawableState(extraSpace + 4);
+    final int[] drawableState = super.onCreateDrawableState(extraSpace + 5);
 
     if (isSelectable) {
       mergeDrawableStates(drawableState, STATE_SELECTABLE);
@@ -78,6 +86,10 @@ public class CalendarCellView extends TextView {
 
     if (isToday) {
       mergeDrawableStates(drawableState, STATE_TODAY);
+    }
+
+    if (isHighlighted) {
+      mergeDrawableStates(drawableState, STATE_HIGHLIGHTED);
     }
 
     if (rangeState == MonthCellDescriptor.RangeState.FIRST) {

--- a/library/src/com/squareup/timessquare/MonthCellDescriptor.java
+++ b/library/src/com/squareup/timessquare/MonthCellDescriptor.java
@@ -16,13 +16,15 @@ class MonthCellDescriptor {
   private boolean isSelected;
   private final boolean isToday;
   private final boolean isSelectable;
+  private boolean isHighlighted;
   private RangeState rangeState;
 
   MonthCellDescriptor(Date date, boolean currentMonth, boolean selectable, boolean selected,
-      boolean today, int value, RangeState rangeState) {
+      boolean today, boolean highlighted, int value, RangeState rangeState) {
     this.date = date;
     isCurrentMonth = currentMonth;
     isSelectable = selectable;
+    isHighlighted = highlighted;
     isSelected = selected;
     isToday = today;
     this.value = value;
@@ -47,6 +49,14 @@ class MonthCellDescriptor {
 
   public void setSelected(boolean selected) {
     isSelected = selected;
+  }
+
+  boolean isHighlighted() {
+    return isHighlighted;
+  }
+
+  void setHighlighted(boolean highlighted) {
+    isHighlighted = highlighted;
   }
 
   public boolean isToday() {
@@ -79,6 +89,8 @@ class MonthCellDescriptor {
         + isToday
         + ", isSelectable="
         + isSelectable
+        + ", isHighlighted="
+        + isHighlighted
         + ", rangeState="
         + rangeState
         + '}';

--- a/library/src/com/squareup/timessquare/MonthView.java
+++ b/library/src/com/squareup/timessquare/MonthView.java
@@ -69,6 +69,7 @@ public class MonthView extends LinearLayout {
           cellView.setCurrentMonth(cell.isCurrentMonth());
           cellView.setToday(cell.isToday());
           cellView.setRangeState(cell.getRangeState());
+          cellView.setHighlighted(cell.isHighlighted());
           cellView.setTag(cell);
         }
       } else {

--- a/library/test/com/squareup/timessquare/CalendarPickerViewTest.java
+++ b/library/test/com/squareup/timessquare/CalendarPickerViewTest.java
@@ -446,6 +446,30 @@ public class CalendarPickerViewTest {
     assertRangeSelectionBehavior();
   }
 
+  @Test
+  public void testInitWithoutHighlightingCells() {
+    view.init(minDate, maxDate, locale)
+        .inMode(SINGLE);
+
+    assertThat(view.highlightedCals).hasSize(0);
+    assertThat(view.highlightedCells).hasSize(0);
+  }
+
+  @Test
+  public void testHighlightingCells() {
+    final Calendar highlightedCal = buildCal(2012, NOVEMBER, 20);
+
+    view.init(minDate, maxDate, locale)
+        .inMode(SINGLE)
+        .withHighlightedDate(highlightedCal.getTime());
+
+    assertThat(view.highlightedCals).hasSize(1);
+    assertThat(view.highlightedCells).hasSize(1);
+
+    List<List<MonthCellDescriptor>> cells = getCells(NOVEMBER, 2012);
+    assertThat(cells.get(3).get(2).isHighlighted()).isTrue();
+  }
+
   private void assertRangeSelectionBehavior() {
     // Start a new range in the middle of the current (Nov 18 - Nov 24) one.
     Calendar nov20 = buildCal(2012, NOVEMBER, 20);


### PR DESCRIPTION
Provides an API for highlighting calendar cells in the grid, e.g. to mark appointments.

This is more of a draft, obviously docs, tests etc. are missing. I was just wondering if this is something that you would accept in general.

Notifying the sub-views of a changed highlight state is currently done by `notifyDataSetChanged`ing and re-setting the `MonthAdapter`. If anyone has an idea about how to do this more elegantly, it'd be very welcome.
