### PR TITLE
Produce aar in addition to apklib

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -52,6 +52,36 @@
         <groupId>com.jayway.maven.plugins.android.generation2</groupId>
         <artifactId>android-maven-plugin</artifactId>
         <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>create-all-formats</id>
+            <phase>package</phase>
+            <goals>
+              <goal>aar</goal>
+              <goal>apklib</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <type>aar</type>
+                  <file>${project.build.directory}/${project.build.finalName}.aar</file>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <plugin>
           <groupId>com.jayway.maven.plugins.android.generation2</groupId>
           <artifactId>android-maven-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.7.0</version>
           <configuration>
             <sdk>
               <platform>${android.platform}</platform>


### PR DESCRIPTION
In #60 I proposed to switch from Maven to Gradle to be able to produce an aar in addition to the apklib. In the meantime a new version of the android-maven-plugin was released that is capable of producing aars, so the switch isn't necessary anymore. Therefore this pull requests makes the required changes to the build files to produce both library formats.

I've seen that there's another effort going on in #64 to replace Maven with Gradle. I investigated that too (see https://github.com/aahlenst/android-times-square/tree/gradle-build) but I don't like the limitations that come with it (especially the lacking install command).
