### PR TITLE
Fix of month name format

### DIFF
--- a/library/res/values/strings.xml
+++ b/library/res/values/strings.xml
@@ -4,5 +4,5 @@
 <resources>
   <string name="day_name_format">EEE</string>
   <string name="invalid_date">Date must be between %1$s and %2$s.</string>
-  <string name="month_name_format">MMMM yyyy</string>
+  <string name="month_name_format">LLLL yyyy</string>
 </resources>


### PR DESCRIPTION
Changed month in year (MMMM) to stand-alone month (LLLL). In polish language stand-alone month sounds better.
