### PR TITLE
Fixed bug where selected date didn't update if an OnDateSelectedListener...

### DIFF
--- a/library/src/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/com/squareup/timessquare/CalendarPickerView.java
@@ -327,14 +327,17 @@ public class CalendarPickerView extends ListView {
         if (invalidDateListener != null) {
           invalidDateListener.onInvalidDateSelected(clickedDate);
         }
-      } else if (dateListener != null) {
+      } else {
         boolean wasSelected = doSelectDate(clickedDate, cell);
-        
-        if (wasSelected) {
-          dateListener.onDateSelected(clickedDate);
-        } else {
-          dateListener.onDateUnselected(clickedDate);
+
+        if (dateListener != null) {
+          if (wasSelected) {
+            dateListener.onDateSelected(clickedDate);
+          } else {
+            dateListener.onDateUnselected(clickedDate);
+          }
         }
+
       }
     }
   }


### PR DESCRIPTION
... wasn't set.

You should be able to reproduce by running the sample application in the current master and clicking on a date. The blue box won't move there.

I just submitted the CLA as well. 

Let me know if there are any problems. Thanks!
