### PR TITLE
Clarified the messaging for selected date exceptions.

### DIFF
--- a/library/src/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/com/squareup/timessquare/CalendarPickerView.java
@@ -431,7 +431,9 @@ public class CalendarPickerView extends ListView {
     }
     if (date.before(minCal.getTime()) || date.after(maxCal.getTime())) {
       throw new IllegalArgumentException(
-          "selectedDate must be between minDate and maxDate.  " + date);
+          String.format("SelectedDate must be between minDate and maxDate."
+                  + "%nminDate: %s%nmaxDate: %s%nselectedDate: %s",
+                  minCal.getTime(), maxCal.getTime(), date));
     }
   }
 

--- a/library/test/com/squareup/timessquare/CalendarPickerViewTest.java
+++ b/library/test/com/squareup/timessquare/CalendarPickerViewTest.java
@@ -334,6 +334,17 @@ public class CalendarPickerViewTest {
     }
   }
 
+  /**
+   * Verify the expectation that the set of dates excludes the max.
+   * In other words, the date interval is [minDate, maxDate)
+   */
+  @Test(expected=IllegalArgumentException.class)
+  public void testSelectedNotInRange_maxDateExcluded() throws Exception {
+    view.init(minDate, maxDate, locale)
+        .inMode(SINGLE)
+        .withSelectedDate(maxDate);
+  }
+
   @Test
   public void testNotCallingInit() throws Exception {
     view = new CalendarPickerView(activity, null);


### PR DESCRIPTION
 Currently, if you set a date range and try to select the last date in that range, it throws an exception but the messaging was vague. Not knowing that the max date is excluded from the date range made this error harder to debug than it should have been. Also, I added unit test that would break if this current API behavior is violated in the future.
