### PR TITLE
Fixed highlighted cells not being cleared.

### DIFF
--- a/library/src/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/com/squareup/timessquare/CalendarPickerView.java
@@ -183,6 +183,7 @@ public class CalendarPickerView extends ListView {
     // Clear out any previously-selected dates/cells.
     selectedCals.clear();
     selectedCells.clear();
+    highlightedCals.clear();
     highlightedCells.clear();
 
     // Clear previous state.


### PR DESCRIPTION
Highlighted cells were not being cleared when re-initialising the calendar. Clearing the list of highlighted Calendar instances fixes this.
