### PR TITLE
add sample for calendar customization

### DIFF
--- a/sample/res/color/custom_calendar_text_selector.xml
+++ b/sample/res/color/custom_calendar_text_selector.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2014 Square, Inc. -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item android:state_selected="true" android:color="@color/custom_text_selected"/>
+    <item android:state_pressed="true" android:color="@color/custom_text_selected"/>
+    <item app:state_current_month="false" android:color="@color/custom_text_inactive"/>
+    <item app:state_today="true" android:color="@color/custom_text_selected"/>
+    <item app:state_selectable="false" android:color="@color/custom_text_inactive" />
+    <item android:color="@color/custom_background_today"/>
+</selector>

--- a/sample/res/drawable/bg_circle_selected.xml
+++ b/sample/res/drawable/bg_circle_selected.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <solid android:color="@color/custom_background"/>
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="@color/custom_selected"/>
+            <stroke
+                    android:width="@dimen/dimen_margin_circle"
+                    android:color="@color/transparent"/>
+        </shape>
+    </item>
+</layer-list>

--- a/sample/res/drawable/bg_circle_today.xml
+++ b/sample/res/drawable/bg_circle_today.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <solid android:color="@color/custom_background"/>
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="@color/custom_background_today"/>
+            <stroke
+                    android:width="@dimen/dimen_margin_circle"
+                    android:color="@color/transparent"/>
+        </shape>
+    </item>
+</layer-list>

--- a/sample/res/drawable/custom_calendar_bg_selector.xml
+++ b/sample/res/drawable/custom_calendar_bg_selector.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item android:state_selected="true" android:drawable="@drawable/bg_circle_selected"/>
+    <item android:state_pressed="true" android:drawable="@drawable/bg_circle_selected"/>
+    <item app:state_current_month="false">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/custom_background_disabled"/>
+        </shape>
+    </item>
+    <item app:state_today="true" android:drawable="@drawable/bg_circle_today"/>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/custom_background"/>
+        </shape>
+    </item>
+</selector>

--- a/sample/res/layout/dialog_customized.xml
+++ b/sample/res/layout/dialog_customized.xml
@@ -1,0 +1,18 @@
+<com.squareup.timessquare.CalendarPickerView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/calendar_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingLeft="16dp"
+        android:paddingRight="16dp"
+        android:paddingBottom="16dp"
+        android:scrollbarStyle="outsideOverlay"
+        android:clipToPadding="false"
+        android:background="@color/custom_background"
+        app:dayBackground="@drawable/custom_calendar_bg_selector"
+        app:dayTextColor="@color/custom_calendar_text_selector"
+        app:dividerColor="@color/transparent"
+        app:titleTextColor="@color/custom_calendar_text_selector"
+        app:headerTextColor="@color/custom_header_text"
+        />

--- a/sample/res/layout/sample_calendar_picker.xml
+++ b/sample/res/layout/sample_calendar_picker.xml
@@ -7,42 +7,56 @@
     android:layout_height="match_parent"
     >
 
-    <LinearLayout
+    <HorizontalScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" >
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:scrollbarStyle="outsideInset">
 
-        <Button
-            android:id="@+id/button_single"
+        <LinearLayout
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Single"
-            android:enabled="false"/>
+            android:layout_height="wrap_content" >
 
-        <Button
-            android:id="@+id/button_multi"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Multi" />
+            <Button
+                android:id="@+id/button_single"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Single"
+                android:enabled="false"/>
 
-        <Button
-            android:id="@+id/button_range"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Range" />
+            <Button
+                android:id="@+id/button_multi"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Multi" />
 
-      <Button
-          android:id="@+id/button_display_only"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:text="DisplayOnly" />
+            <Button
+                android:id="@+id/button_range"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Range" />
 
-      <Button
-          android:id="@+id/button_dialog"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:text="Dialog" />
+            <Button
+                android:id="@+id/button_display_only"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="DisplayOnly" />
 
-    </LinearLayout>
+            <Button
+                android:id="@+id/button_dialog"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Dialog" />
+
+            <Button
+                android:id="@+id/button_customized"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Customized" />
+
+        </LinearLayout>
+
+    </HorizontalScrollView>
 
   <com.squareup.timessquare.CalendarPickerView
       android:id="@+id/calendar_view"

--- a/sample/res/values/colors.xml
+++ b/sample/res/values/colors.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="custom_header_text">#85B100</color>
+    <color name="custom_selected">#A8D324</color>
+    <color name="custom_background">#F0F8DB</color>
+    <color name="custom_background_today">#FF9105</color>
+    <color name="custom_background_disabled">#F0F8DB</color>
+    <color name="custom_text_selected">#FFFFFFFF</color>
+    <color name="custom_text_inactive">#7f778088</color>
+    <color name="transparent">#00000000</color>
+</resources>

--- a/sample/res/values/dimens.xml
+++ b/sample/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="dimen_margin_circle">4dp</dimen>
+    <dimen name="dimen_margin_circle.negative">-4dp</dimen>
+</resources>

--- a/sample/src/com/squareup/timessquare/sample/SampleTimesSquareActivity.java
+++ b/sample/src/com/squareup/timessquare/sample/SampleTimesSquareActivity.java
@@ -45,6 +45,7 @@ public class SampleTimesSquareActivity extends Activity {
     final Button range = (Button) findViewById(R.id.button_range);
     final Button displayOnly = (Button) findViewById(R.id.button_display_only);
     final Button dialog = (Button) findViewById(R.id.button_dialog);
+    final Button customized = (Button) findViewById(R.id.button_customized);
     single.setOnClickListener(new OnClickListener() {
       @Override
       public void onClick(View v) {
@@ -129,7 +130,34 @@ public class SampleTimesSquareActivity extends Activity {
                 })
                 .create();
         theDialog.setOnShowListener(new DialogInterface.OnShowListener() {
-          @Override public void onShow(DialogInterface dialogInterface) {
+          @Override
+          public void onShow(DialogInterface dialogInterface) {
+            Log.d(TAG, "onShow: fix the dimens!");
+            dialogView.fixDialogDimens();
+          }
+        });
+        theDialog.show();
+      }
+    });
+
+    customized.setOnClickListener(new OnClickListener() {
+      @Override
+      public void onClick(View view) {
+        dialogView = (CalendarPickerView) getLayoutInflater() //
+            .inflate(R.layout.dialog_customized, null, false);
+        dialogView.init(lastYear.getTime(), nextYear.getTime()).withSelectedDate(new Date());
+        theDialog =
+            new AlertDialog.Builder(SampleTimesSquareActivity.this).setTitle("Pimp my calendar !")
+                .setView(dialogView)
+                .setNeutralButton("Dismiss", new DialogInterface.OnClickListener() {
+                  @Override
+                  public void onClick(DialogInterface dialogInterface, int i) {
+                    dialogInterface.dismiss();
+                  }
+                }).create();
+        theDialog.setOnShowListener(new DialogInterface.OnShowListener() {
+          @Override
+          public void onShow(DialogInterface dialogInterface) {
             Log.d(TAG, "onShow: fix the dimens!");
             dialogView.fixDialogDimens();
           }


### PR DESCRIPTION
Thanks for releasing the new customization features.

As a result, I added a small sample to show how to customize the calendar.
I added customization for a basic calendar, not a ranged one. 
Feel free to ask for more customization if needed.

I also changed a bit the main layout of the sample activity to add the new button in the header bar. I just added a scroll view.

![screenshot_2014-06-10-14-55-14](https://cloud.githubusercontent.com/assets/3300620/3230117/3382166e-f09f-11e3-98af-422b515ee0ee.png)
