### PR TITLE
Added a fix to get the correct default title and header text colors

### DIFF
--- a/library/src/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/com/squareup/timessquare/CalendarPickerView.java
@@ -106,11 +106,11 @@ public class CalendarPickerView extends ListView {
         R.drawable.calendar_bg_selector);
     dayTextColorResId = a.getResourceId(R.styleable.CalendarPickerView_dayTextColor,
         R.color.calendar_text_selector);
-    titleTextColor =
-        a.getColor(R.styleable.CalendarPickerView_titleTextColor, R.color.calendar_text_active);
+    titleTextColor = a.getColor(R.styleable.CalendarPickerView_titleTextColor,
+        res.getColor(R.color.calendar_text_active));
     displayHeader = a.getBoolean(R.styleable.CalendarPickerView_displayHeader, true);
-    headerTextColor =
-        a.getColor(R.styleable.CalendarPickerView_headerTextColor, R.color.calendar_text_active);
+    headerTextColor = a.getColor(R.styleable.CalendarPickerView_headerTextColor,
+        res.getColor(R.color.calendar_text_active));
     a.recycle();
 
     adapter = new MonthAdapter();


### PR DESCRIPTION
The `titleTextColor` and `headerTextColor` were defaulting to the resource ID value for `R.color.calendar_text_active` as a fallback, rather than getting the actual color value, which led to a "random" color being used. I fixed it to get the actual color, and now the correct default color is showing.
