### PR TITLE
When calculating cell width, make sure to cover all of totalWidth.

### DIFF
--- a/library/src/com/squareup/timessquare/CalendarRowView.java
+++ b/library/src/com/squareup/timessquare/CalendarRowView.java
@@ -17,7 +17,6 @@ import static android.view.View.MeasureSpec.makeMeasureSpec;
 public class CalendarRowView extends ViewGroup implements View.OnClickListener {
   private boolean isHeaderRow;
   private MonthView.Listener listener;
-  private int cellSize;
 
   public CalendarRowView(Context context, AttributeSet attrs) {
     super(context, attrs);
@@ -31,12 +30,15 @@ public class CalendarRowView extends ViewGroup implements View.OnClickListener {
   @Override protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
     long start = System.currentTimeMillis();
     final int totalWidth = MeasureSpec.getSize(widthMeasureSpec);
-    cellSize = totalWidth / 7;
-    int cellWidthSpec = makeMeasureSpec(cellSize, EXACTLY);
-    int cellHeightSpec = isHeaderRow ? makeMeasureSpec(cellSize, AT_MOST) : cellWidthSpec;
     int rowHeight = 0;
     for (int c = 0, numChildren = getChildCount(); c < numChildren; c++) {
       final View child = getChildAt(c);
+      // Calculate width cells, making sure to cover totalWidth.
+      int l = ((c + 0) * totalWidth) / 7;
+      int r = ((c + 1) * totalWidth) / 7;
+      int cellSize = r - l;
+      int cellWidthSpec = makeMeasureSpec(cellSize, EXACTLY);
+      int cellHeightSpec = isHeaderRow ? makeMeasureSpec(cellSize, AT_MOST) : cellWidthSpec;
       child.measure(cellWidthSpec, cellHeightSpec);
       // The row height is the height of the tallest cell.
       if (child.getMeasuredHeight() > rowHeight) {
@@ -52,9 +54,12 @@ public class CalendarRowView extends ViewGroup implements View.OnClickListener {
   @Override protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
     long start = System.currentTimeMillis();
     int cellHeight = bottom - top;
+    int width = (right - left);
     for (int c = 0, numChildren = getChildCount(); c < numChildren; c++) {
       final View child = getChildAt(c);
-      child.layout(c * cellSize, 0, (c + 1) * cellSize, cellHeight);
+      int l = ((c + 0) * width) / 7;
+      int r = ((c + 1) * width) / 7;
+      child.layout(l, 0, r, cellHeight);
     }
     Logr.d("Row.onLayout %d ms", System.currentTimeMillis() - start);
   }


### PR DESCRIPTION
Fixes: range selections did not cover all pixels to edge of screen, since very few screens have a width where (totalWidth % 7) == 0.

Patch makes the cells have a width of either floor(totalWidth / 7) or ceil(totalWidth / 7) so that the sum of the widths end up being totalWidth.