### PR TITLE
Init calendar with Collection of dates instead of date range (optional). Plus `scrollToDate(Date date)` and `unHighlightAllDates()` independent methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ Change Log
 Version 1.5.1 *(2015-01-??)*
 ----------------------------
 
- * New: init(Collection<Date> datesCollection) - Initiate calendar with Collection of dates,
+ * New: `init(Collection<Date> datesCollection)` - Initiate calendar with Collection of dates,
    where the date range does not have to be continuous.
- * New: unHighlightAllDates() - Unhighlights all previously highlighted days.
- * New: scrollToDate(Date date) - Scroll to the month that given date belongs to.
+ * New: `clearHighlightedDates()` - Unhighlights all previously highlighted days.
+ * New: `scrollToDate(Date date)` - Scroll to the month that given date belongs to.
  * Fix: When calculating cell width, make sure to cover all of totalWidth.
 
 Version 1.5.0 *(2014-12-15)*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Change Log
 Version 1.5.1 *(2015-01-??)*
 ----------------------------
 
+ * New: init(Collection<Date> datesCollection) - Initiate calendar with Collection of dates,
+   where the date range does not have to be continuous.
  * New: unHighlightAllDates() - Unhighlights all previously highlighted days.
  * New: scrollToDate(Date date) - Scroll to the month that given date belongs to.
  * Fix: When calculating cell width, make sure to cover all of totalWidth.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+Version 1.5.1 *(2015-01-??)*
+----------------------------
+
+ * New: unHighlightAllDates() - Unhighlights all previously highlighted days.
+ * New: scrollToDate(Date date) - Scroll to the month that given date belongs to.
+ * Fix: When calculating cell width, make sure to cover all of totalWidth.
+
 Version 1.5.0 *(2014-12-15)*
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ calendar.init(today, nextYear.getTime())
     .inMode(RANGE);
 ```
 
+If you want to be able to select dates in not continuous range, initiate calendar with collection
+of dates:
+
+```java
+protected Collection<Date> mSelectableDates = new ArrayList<Date>() {};
+protected long[] timestampArray = new long[count];
+
+// create all dates you want to be selectable, e.g. dates with events
+for (int i = 0; i < timestampArray.length; i++) {
+    mSelectableDates.add(new Date(timestampArray[i]));
+}
+
+calendar.init(mSelectableDates)
+    .inMode(SelectionMode.SINGLE);
+```
+
 
 Download
 --------

--- a/README.md
+++ b/README.md
@@ -49,16 +49,9 @@ If you want to be able to select dates in not continuous range, initiate calenda
 of dates:
 
 ```java
-protected Collection<Date> mSelectableDates = new ArrayList<Date>() {};
-protected long[] timestampArray = new long[count];
+Collection<Date> selectableDates = new ArrayList<Date>() {};
 
-// create all dates you want to be selectable, e.g. dates with events
-for (int i = 0; i < timestampArray.length; i++) {
-    mSelectableDates.add(new Date(timestampArray[i]));
-}
-
-calendar.init(mSelectableDates)
-    .inMode(SelectionMode.SINGLE);
+calendar.init(selectableDates);
 ```
 
 

--- a/library/src/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/com/squareup/timessquare/CalendarPickerView.java
@@ -67,8 +67,10 @@ public class CalendarPickerView extends ListView {
   final List<MonthDescriptor> months = new ArrayList<MonthDescriptor>();
   final List<MonthCellDescriptor> selectedCells = new ArrayList<MonthCellDescriptor>();
   final List<MonthCellDescriptor> highlightedCells = new ArrayList<MonthCellDescriptor>();
+  final List<Calendar> selectableCals = new ArrayList<Calendar>();
   final List<Calendar> selectedCals = new ArrayList<Calendar>();
   final List<Calendar> highlightedCals = new ArrayList<Calendar>();
+  private boolean isCheckDayInSelectableCals = false;
   private Locale locale;
   private DateFormat monthNameFormat;
   private DateFormat weekdayNameFormat;
@@ -246,6 +248,77 @@ public class CalendarPickerView extends ListView {
    */
   public FluentInitializer init(Date minDate, Date maxDate) {
     return init(minDate, maxDate, Locale.getDefault());
+  }
+
+  /**
+   * {@code datesCollection} must be non-null and all of it's items' {@link Date#getTime()} must
+   * not return 0. Time of all days will be ignored.
+   * For instance, if you pass in a collection of dates: 11/16/2012, 11/17/2012 and 11/20/2012,
+   * Only these particular dates will be selectable. Meaning that 11/18/2012 and 11/19/2012 will
+   * not be selectable although they will fall into {@code minDate} - {@code maxDate} interval.
+   * {@code minDate} will be set to 11/16/2012 and {@code maxDate} to 11/20/2012.
+   * <p>
+   * This will implicitly set the {@link SelectionMode} to {@link SelectionMode#SINGLE}.  If you
+   * want a different selection mode, use {@link FluentInitializer#inMode(SelectionMode)} on the
+   * {@link FluentInitializer} this method returns.
+   * <p>
+   * The calendar will be constructed using the given locale. This means that all names
+   * (months, days) will be in the language of the locale and the weeks start with the day
+   * specified by the locale.
+   *
+   * @param datesCollection collection of selectable dates.
+   */
+  public FluentInitializer init(Collection<Date> datesCollection, Locale locale) {
+    if (datesCollection.isEmpty()){
+      throw new IllegalArgumentException(
+          "daysCollection is empty.");
+    }
+    
+    Date minDate = datesCollection.iterator().next();
+    Date maxDate = datesCollection.iterator().next();
+    for (Date date : datesCollection)
+    {
+      Calendar cal = Calendar.getInstance(locale);
+      cal.setTime(date);
+      setMidnight(cal);
+      selectableCals.add(cal);
+      
+      if (date.after(maxDate)) maxDate = date;
+      else if (date.before(minDate)) minDate = date;
+    }
+    
+    // maxDate is exclusive. So it should be one day after max day of datesCollection
+    Calendar cal = Calendar.getInstance(locale); 
+    cal.setTime(maxDate); 
+    cal.add(DATE, 1);
+    maxDate = cal.getTime();
+    
+    // this indicates whether to check if a day is in selectableCals Collection
+    isCheckDayInSelectableCals = true;
+    
+    return init(minDate, maxDate, locale);
+  }
+  
+  /**
+   * {@code datesCollection} must be non-null and all of it's items' {@link Date#getTime()} must
+   * not return 0. Time of all days will be ignored.
+   * For instance, if you pass in a collection of dates: 11/16/2012, 11/17/2012 and 11/20/2012,
+   * only these particular dates will be selectable. Meaning that 11/18/2012 and 11/19/2012 will
+   * not be selectable although they will fall into {@code minDate} - {@code maxDate} interval.
+   * {@code minDate} will be set to 11/16/2012 and {@code maxDate} to 11/20/2012.
+   * <p>
+   * This will implicitly set the {@link SelectionMode} to {@link SelectionMode#SINGLE}.  If you
+   * want a different selection mode, use {@link FluentInitializer#inMode(SelectionMode)} on the
+   * {@link FluentInitializer} this method returns.
+   * <p>
+   * The calendar will be constructed using the default locale as returned by
+   * {@link java.util.Locale#getDefault()}. If you wish the calendar to be constructed using a
+   * different locale, use {@link #init(java.util.Collection, java.util.Locale)}.
+   *
+   * @param datesCollection collection of selectable dates.
+   */
+  public FluentInitializer init(Collection<Date> datesCollection) {
+    return init(datesCollection, Locale.getDefault());
   }
 
   public class FluentInitializer {
@@ -808,6 +881,12 @@ public class CalendarPickerView extends ListView {
     return cells;
   }
 
+  private boolean containsDate(List<Calendar> selectedCals, Date day) {
+    Calendar cal = Calendar.getInstance(locale);
+    cal.setTime(day);
+    return containsDate(selectedCals, cal);
+  }
+  
   private static boolean containsDate(List<Calendar> selectedCals, Calendar cal) {
     for (Calendar selectedCal : selectedCals) {
       if (sameDate(cal, selectedCal)) {
@@ -855,6 +934,7 @@ public class CalendarPickerView extends ListView {
   }
 
   private boolean isDateSelectable(Date date) {
+    if (isCheckDayInSelectableCals && !containsDate(selectableCals, date)) return false;
     return dateConfiguredListener == null || dateConfiguredListener.isDateSelectable(date);
   }
 

--- a/library/src/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/com/squareup/timessquare/CalendarPickerView.java
@@ -250,73 +250,38 @@ public class CalendarPickerView extends ListView {
     return init(minDate, maxDate, Locale.getDefault());
   }
 
-  /**
-   * {@code datesCollection} must be non-null and all of it's items' {@link Date#getTime()} must
-   * not return 0. Time of all days will be ignored.
-   * For instance, if you pass in a collection of dates: 11/16/2012, 11/17/2012 and 11/20/2012,
-   * Only these particular dates will be selectable. Meaning that 11/18/2012 and 11/19/2012 will
-   * not be selectable although they will fall into {@code minDate} - {@code maxDate} interval.
-   * {@code minDate} will be set to 11/16/2012 and {@code maxDate} to 11/20/2012.
-   * <p>
-   * This will implicitly set the {@link SelectionMode} to {@link SelectionMode#SINGLE}.  If you
-   * want a different selection mode, use {@link FluentInitializer#inMode(SelectionMode)} on the
-   * {@link FluentInitializer} this method returns.
-   * <p>
-   * The calendar will be constructed using the given locale. This means that all names
-   * (months, days) will be in the language of the locale and the weeks start with the day
-   * specified by the locale.
-   *
-   * @param datesCollection collection of selectable dates.
-   */
   public FluentInitializer init(Collection<Date> datesCollection, Locale locale) {
-    if (datesCollection.isEmpty()){
+    if (datesCollection.isEmpty()) {
       throw new IllegalArgumentException(
           "daysCollection is empty.");
     }
-    
+
     Date minDate = datesCollection.iterator().next();
     Date maxDate = datesCollection.iterator().next();
-    for (Date date : datesCollection)
-    {
+    for (Date date : datesCollection) {
       Calendar cal = Calendar.getInstance(locale);
       cal.setTime(date);
       setMidnight(cal);
       selectableCals.add(cal);
-      
-      if (date.after(maxDate)) maxDate = date;
-      else if (date.before(minDate)) minDate = date;
+      if (date.after(maxDate)) {
+          maxDate = date;
+      } else if (date.before(minDate)) {
+          minDate = date;
+      }
     }
-    
+
     // maxDate is exclusive. So it should be one day after max day of datesCollection
-    Calendar cal = Calendar.getInstance(locale); 
-    cal.setTime(maxDate); 
+    Calendar cal = Calendar.getInstance(locale);
+    cal.setTime(maxDate);
     cal.add(DATE, 1);
     maxDate = cal.getTime();
-    
+
     // this indicates whether to check if a day is in selectableCals Collection
     isCheckDayInSelectableCals = true;
-    
+
     return init(minDate, maxDate, locale);
   }
-  
-  /**
-   * {@code datesCollection} must be non-null and all of it's items' {@link Date#getTime()} must
-   * not return 0. Time of all days will be ignored.
-   * For instance, if you pass in a collection of dates: 11/16/2012, 11/17/2012 and 11/20/2012,
-   * only these particular dates will be selectable. Meaning that 11/18/2012 and 11/19/2012 will
-   * not be selectable although they will fall into {@code minDate} - {@code maxDate} interval.
-   * {@code minDate} will be set to 11/16/2012 and {@code maxDate} to 11/20/2012.
-   * <p>
-   * This will implicitly set the {@link SelectionMode} to {@link SelectionMode#SINGLE}.  If you
-   * want a different selection mode, use {@link FluentInitializer#inMode(SelectionMode)} on the
-   * {@link FluentInitializer} this method returns.
-   * <p>
-   * The calendar will be constructed using the default locale as returned by
-   * {@link java.util.Locale#getDefault()}. If you wish the calendar to be constructed using a
-   * different locale, use {@link #init(java.util.Collection, java.util.Locale)}.
-   *
-   * @param datesCollection collection of selectable dates.
-   */
+
   public FluentInitializer init(Collection<Date> datesCollection) {
     return init(datesCollection, Locale.getDefault());
   }
@@ -432,17 +397,10 @@ public class CalendarPickerView extends ListView {
       scrollToSelectedMonth(todayIndex);
     }
   }
-  
-  /**
-   * Scroll to the month that given date belongs to.
-   *
-   * @param date the day you want to be visible
-   * 
-   * @return true if this day and month is in the view, false otherwise
-   */
+
   public boolean scrollToDate(Date date) {
     Integer selectedIndex = null;
-    
+
     Calendar cal = Calendar.getInstance(locale);
     cal.setTime(date);
     for (int c = 0; c < months.size(); c++) {
@@ -743,14 +701,9 @@ public class CalendarPickerView extends ListView {
     }
 
     adapter.notifyDataSetChanged();
-    setAdapter(adapter);
   }
 
-  /**
-   * Unhighlights all previously highlighted days.
-   * Also clears {@link #highlightedCells} and {@link #highlightedCals}.
-   */
-  public void unHighlightAllDates() {
+  public void clearHighlightedDates() {
     for (MonthCellDescriptor cal : highlightedCells) {
       cal.setHighlighted(false);
     }
@@ -758,7 +711,6 @@ public class CalendarPickerView extends ListView {
     highlightedCals.clear();
 
     adapter.notifyDataSetChanged();
-    setAdapter(adapter);
   }
 
   /** Hold a cell with a month-index. */
@@ -886,7 +838,7 @@ public class CalendarPickerView extends ListView {
     cal.setTime(day);
     return containsDate(selectedCals, cal);
   }
-  
+
   private static boolean containsDate(List<Calendar> selectedCals, Calendar cal) {
     for (Calendar selectedCal : selectedCals) {
       if (sameDate(cal, selectedCal)) {
@@ -934,7 +886,9 @@ public class CalendarPickerView extends ListView {
   }
 
   private boolean isDateSelectable(Date date) {
-    if (isCheckDayInSelectableCals && !containsDate(selectableCals, date)) return false;
+    if (isCheckDayInSelectableCals && !containsDate(selectableCals, date)) {
+        return false;
+    }
     return dateConfiguredListener == null || dateConfiguredListener.isDateSelectable(date);
   }
 

--- a/library/src/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/com/squareup/timessquare/CalendarPickerView.java
@@ -359,6 +359,32 @@ public class CalendarPickerView extends ListView {
       scrollToSelectedMonth(todayIndex);
     }
   }
+  
+  /**
+   * Scroll to the month that given date belongs to.
+   *
+   * @param date the day you want to be visible
+   * 
+   * @return true if this day and month is in the view, false otherwise
+   */
+  public boolean scrollToDate(Date date) {
+    Integer selectedIndex = null;
+    
+    Calendar cal = Calendar.getInstance(locale);
+    cal.setTime(date);
+    for (int c = 0; c < months.size(); c++) {
+      MonthDescriptor month = months.get(c);
+      if (sameMonth(cal, month)) {
+        selectedIndex = c;
+        break;
+      }
+    }
+    if (selectedIndex != null) {
+      scrollToSelectedMonth(selectedIndex);
+      return true;
+    }
+    return false;
+  }
 
   /**
    * This method should only be called if the calendar is contained in a dialog, and it should only
@@ -642,6 +668,21 @@ public class CalendarPickerView extends ListView {
         cell.setHighlighted(true);
       }
     }
+
+    adapter.notifyDataSetChanged();
+    setAdapter(adapter);
+  }
+
+  /**
+   * Unhighlights all previously highlighted days.
+   * Also clears {@link #highlightedCells} and {@link #highlightedCals}.
+   */
+  public void unHighlightAllDates() {
+    for (MonthCellDescriptor cal : highlightedCells) {
+      cal.setHighlighted(false);
+    }
+    highlightedCells.clear();
+    highlightedCals.clear();
 
     adapter.notifyDataSetChanged();
     setAdapter(adapter);


### PR DESCRIPTION
 * New: init(Collection&lt;Date&gt; datesCollection) - Initiate calendar with Collection of dates,
   where the date range does not have to be continuous.
 * New: unHighlightAllDates() - Unhighlights all previously highlighted days.
 * New: scrollToDate(Date date) - Scroll to the month that given date belongs to.