### PR TITLE
Option to select a single date as range

### DIFF
--- a/library/res/drawable/calendar_bg_selector.xml
+++ b/library/res/drawable/calendar_bg_selector.xml
@@ -6,6 +6,9 @@
   <item app:state_range_middle="true">
     <color android:color="@color/calendar_selected_range_bg"/>
   </item>
+  <item app:state_selected_twice="true">
+    <color android:color="@color/calendar_selected_twice_day_bg"/>
+  </item>
   <item android:state_selected="true">
     <color android:color="@color/calendar_selected_day_bg"/>
   </item>

--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -2,6 +2,7 @@
 <resources>
   <declare-styleable name="CalendarPickerView">
     <attr name="android:background"/>
+    <attr name="supportsSingleDateRagne" format="boolean"/>
     <attr name="dividerColor" format="color"/>
     <attr name="dayBackground" format="reference"/>
     <attr name="dayTextColor" format="color"/>
@@ -16,6 +17,7 @@
     <attr name="state_today" format="boolean" />
     <attr name="state_range_first" format="boolean" />
     <attr name="state_range_middle" format="boolean" />
+    <attr name="state_selected_twice" format="boolean" />
     <attr name="state_range_last" format="boolean" />
     <attr name="state_highlighted" format="boolean" />
   </declare-styleable>

--- a/library/res/values/colors.xml
+++ b/library/res/values/colors.xml
@@ -5,6 +5,7 @@
   <color name="calendar_divider">#ffbababa</color>
   <color name="calendar_inactive_month_bg">#ffd7d9db</color>
   <color name="calendar_selected_day_bg">#ff379bff</color>
+  <color name="calendar_selected_twice_day_bg">#FF3773FF</color>
   <color name="calendar_highlighted_day_bg">#ccffcc</color>
   <color name="calendar_selected_range_bg">#ff96caff</color>
   <color name="calendar_text_inactive">#40778088</color>

--- a/library/src/com/squareup/timessquare/CalendarCellView.java
+++ b/library/src/com/squareup/timessquare/CalendarCellView.java
@@ -5,6 +5,7 @@ package com.squareup.timessquare;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.widget.TextView;
+
 import com.squareup.timessquare.MonthCellDescriptor.RangeState;
 
 public class CalendarCellView extends TextView {
@@ -28,6 +29,9 @@ public class CalendarCellView extends TextView {
   };
   private static final int[] STATE_RANGE_LAST = {
       R.attr.state_range_last
+  };
+  private static final int[] STATE_RANGE_SELECTED_TWICE = {
+      R.attr.state_selected_twice
   };
 
   private boolean isSelectable = false;
@@ -89,8 +93,10 @@ public class CalendarCellView extends TextView {
       mergeDrawableStates(drawableState, STATE_RANGE_FIRST);
     } else if (rangeState == MonthCellDescriptor.RangeState.MIDDLE) {
       mergeDrawableStates(drawableState, STATE_RANGE_MIDDLE);
-    } else if (rangeState == RangeState.LAST) {
+    } else if (rangeState == MonthCellDescriptor.RangeState.LAST) {
       mergeDrawableStates(drawableState, STATE_RANGE_LAST);
+    } else if (rangeState == MonthCellDescriptor.RangeState.SELECTED_TWICE) {
+      mergeDrawableStates(drawableState, STATE_RANGE_SELECTED_TWICE);
     }
 
     return drawableState;

--- a/library/src/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/com/squareup/timessquare/CalendarPickerView.java
@@ -79,6 +79,7 @@ public class CalendarPickerView extends ListView {
   private boolean displayOnly;
   SelectionMode selectionMode;
   Calendar today;
+  private boolean supportsSingleDateRange;
   private int dividerColor;
   private int dayBackgroundResId;
   private int dayTextColorResId;
@@ -112,6 +113,7 @@ public class CalendarPickerView extends ListView {
     displayHeader = a.getBoolean(R.styleable.CalendarPickerView_displayHeader, true);
     headerTextColor = a.getColor(R.styleable.CalendarPickerView_headerTextColor,
         res.getColor(R.color.calendar_text_active));
+    supportsSingleDateRange = a.getBoolean(R.styleable.CalendarPickerView_supportsSingleDateRagne, false);
     a.recycle();
 
     adapter = new MonthAdapter();
@@ -584,9 +586,18 @@ public class CalendarPickerView extends ListView {
 
     if (date != null) {
       // Select a new cell.
-      if (selectedCells.size() == 0 || !selectedCells.get(0).equals(cell)) {
-        selectedCells.add(cell);
-        cell.setSelected(true);
+      if (supportsSingleDateRange) {
+          boolean selectedTwice = selectedCells.contains(cell);
+          selectedCells.add(cell);
+          cell.setSelected(true);
+          if (selectedTwice) {
+              cell.setRangeState(RangeState.SELECTED_TWICE);
+          }
+      } else {
+          if (selectedCells.size() == 0 || !selectedCells.get(0).equals(cell)) {
+              selectedCells.add(cell);
+              cell.setSelected(true);
+          }
       }
       selectedCals.add(newlySelectedCal);
 
@@ -594,8 +605,10 @@ public class CalendarPickerView extends ListView {
         // Select all days in between start and end.
         Date start = selectedCells.get(0).getDate();
         Date end = selectedCells.get(1).getDate();
-        selectedCells.get(0).setRangeState(MonthCellDescriptor.RangeState.FIRST);
-        selectedCells.get(1).setRangeState(MonthCellDescriptor.RangeState.LAST);
+        if (supportsSingleDateRange && selectedCells.get(0).getRangeState() != RangeState.SELECTED_TWICE) {
+            selectedCells.get(0).setRangeState(MonthCellDescriptor.RangeState.FIRST);
+            selectedCells.get(1).setRangeState(MonthCellDescriptor.RangeState.LAST);
+        }
 
         for (List<List<MonthCellDescriptor>> month : cells) {
           for (List<MonthCellDescriptor> week : month) {

--- a/library/src/com/squareup/timessquare/MonthCellDescriptor.java
+++ b/library/src/com/squareup/timessquare/MonthCellDescriptor.java
@@ -7,7 +7,7 @@ import java.util.Date;
 /** Describes the state of a particular date cell in a {@link MonthView}. */
 class MonthCellDescriptor {
   public enum RangeState {
-    NONE, FIRST, MIDDLE, LAST
+    NONE, FIRST, MIDDLE, LAST, SELECTED_TWICE
   }
 
   private final Date date;


### PR DESCRIPTION
'supportSingleDateRange' parameter added, allowing to select a single date cell as both beginning and end of the range.
Cell that is selected twice has separate coloring.'
Implements suggestions #182 