### PR TITLE
Expose CalendarCellView state

### DIFF
--- a/library/src/com/squareup/timessquare/CalendarCellView.java
+++ b/library/src/com/squareup/timessquare/CalendarCellView.java
@@ -66,6 +66,18 @@ public class CalendarCellView extends TextView {
     refreshDrawableState();
   }
 
+  public boolean isCurrentMonth() {
+    return isCurrentMonth;
+  }
+
+  public boolean isToday() {
+    return isToday;
+  }
+
+  public boolean isSelectable() {
+    return isSelectable;
+  }
+
   @Override protected int[] onCreateDrawableState(int extraSpace) {
     final int[] drawableState = super.onCreateDrawableState(extraSpace + 5);
 


### PR DESCRIPTION
Hi, I'm using CalendarCellDecorators to draw different icons over some cells, and It would be very helpful to have access to the internal cell state (`isToday`, `isCurrentMonth`, `isSelectable`) to deal with these cases (don't draw them twice, handle icon/today ocurrences, etc.). I found that `isCurrentMonth` and `isEnabled()` from TextView are actually the same, but i didn't found any supported way to get the others. In any case, i think this way is more clear and easy to understand. Do you see any problem?