### PR TITLE
CalendarCell optimization

### DIFF
--- a/library/src/com/squareup/timessquare/CalendarCellView.java
+++ b/library/src/com/squareup/timessquare/CalendarCellView.java
@@ -5,118 +5,116 @@ package com.squareup.timessquare;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.widget.TextView;
-
 import com.squareup.timessquare.MonthCellDescriptor.RangeState;
 
 public class CalendarCellView extends TextView {
-    private static final int[] STATE_SELECTABLE = {
-            R.attr.state_selectable
-    };
-    private static final int[] STATE_CURRENT_MONTH = {
-            R.attr.state_current_month
-    };
-    private static final int[] STATE_TODAY = {
-            R.attr.state_today
-    };
-    private static final int[] STATE_HIGHLIGHTED = {
-            R.attr.state_highlighted
-    };
-    private static final int[] STATE_RANGE_FIRST = {
-            R.attr.state_range_first
-    };
-    private static final int[] STATE_RANGE_MIDDLE = {
-            R.attr.state_range_middle
-    };
-    private static final int[] STATE_RANGE_LAST = {
-            R.attr.state_range_last
-    };
+  private static final int[] STATE_SELECTABLE = {
+      R.attr.state_selectable
+  };
+  private static final int[] STATE_CURRENT_MONTH = {
+      R.attr.state_current_month
+  };
+  private static final int[] STATE_TODAY = {
+      R.attr.state_today
+  };
+  private static final int[] STATE_HIGHLIGHTED = {
+      R.attr.state_highlighted
+  };
+  private static final int[] STATE_RANGE_FIRST = {
+      R.attr.state_range_first
+  };
+  private static final int[] STATE_RANGE_MIDDLE = {
+      R.attr.state_range_middle
+  };
+  private static final int[] STATE_RANGE_LAST = {
+      R.attr.state_range_last
+  };
 
-    private boolean isSelectable = false;
-    private boolean isCurrentMonth = false;
-    private boolean isToday = false;
-    private boolean isHighlighted = false;
-    private RangeState rangeState = RangeState.NONE;
+  private boolean isSelectable = false;
+  private boolean isCurrentMonth = false;
+  private boolean isToday = false;
+  private boolean isHighlighted = false;
+  private RangeState rangeState = RangeState.NONE;
 
-    @SuppressWarnings("UnusedDeclaration") //
-    public CalendarCellView(Context context, AttributeSet attrs) {
-        super(context, attrs);
+  @SuppressWarnings("UnusedDeclaration") //
+  public CalendarCellView(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  public void setSelectable(boolean isSelectable) {
+    if (this.isSelectable != isSelectable) {
+      this.isSelectable = isSelectable;
+      refreshDrawableState();
+    }
+  }
+
+  public void setCurrentMonth(boolean isCurrentMonth) {
+    if (this.isCurrentMonth != isCurrentMonth) {
+      this.isCurrentMonth = isCurrentMonth;
+      refreshDrawableState();
+    }
+  }
+
+  public void setToday(boolean isToday) {
+    if (this.isToday != isToday) {
+      this.isToday = isToday;
+      refreshDrawableState();
+    }
+  }
+
+  public void setRangeState(MonthCellDescriptor.RangeState rangeState) {
+    if (this.rangeState != rangeState) {
+      this.rangeState = rangeState;
+      refreshDrawableState();
+    }
+  }
+
+  public void setHighlighted(boolean highlighted) {
+    if (this.isHighlighted != isHighlighted) {
+      isHighlighted = highlighted;
+      refreshDrawableState();
+    }
+  }
+
+  public boolean isCurrentMonth() {
+    return isCurrentMonth;
+  }
+
+  public boolean isToday() {
+    return isToday;
+  }
+
+  public boolean isSelectable() {
+    return isSelectable;
+  }
+
+  @Override protected int[] onCreateDrawableState(int extraSpace) {
+    final int[] drawableState = super.onCreateDrawableState(extraSpace + 5);
+
+    if (isSelectable) {
+      mergeDrawableStates(drawableState, STATE_SELECTABLE);
     }
 
-    public void setSelectable(boolean isSelectable) {
-        if (this.isSelectable != isSelectable) {
-            this.isSelectable = isSelectable;
-            refreshDrawableState();
-        }
+    if (isCurrentMonth) {
+      mergeDrawableStates(drawableState, STATE_CURRENT_MONTH);
     }
 
-    public void setCurrentMonth(boolean isCurrentMonth) {
-        if (this.isCurrentMonth != isCurrentMonth) {
-            this.isCurrentMonth = isCurrentMonth;
-            refreshDrawableState();
-        }
+    if (isToday) {
+      mergeDrawableStates(drawableState, STATE_TODAY);
     }
 
-    public void setToday(boolean isToday) {
-        if (this.isToday != isToday) {
-            this.isToday = isToday;
-            refreshDrawableState();
-        }
+    if (isHighlighted) {
+      mergeDrawableStates(drawableState, STATE_HIGHLIGHTED);
     }
 
-    public void setRangeState(MonthCellDescriptor.RangeState rangeState) {
-        if (this.rangeState != rangeState) {
-            this.rangeState = rangeState;
-            refreshDrawableState();
-        }
+    if (rangeState == MonthCellDescriptor.RangeState.FIRST) {
+      mergeDrawableStates(drawableState, STATE_RANGE_FIRST);
+    } else if (rangeState == MonthCellDescriptor.RangeState.MIDDLE) {
+      mergeDrawableStates(drawableState, STATE_RANGE_MIDDLE);
+    } else if (rangeState == RangeState.LAST) {
+      mergeDrawableStates(drawableState, STATE_RANGE_LAST);
     }
 
-    public void setHighlighted(boolean highlighted) {
-        if (this.isHighlighted != highlighted) {
-            isHighlighted = highlighted;
-            refreshDrawableState();
-        }
-    }
-
-    public boolean isCurrentMonth() {
-        return isCurrentMonth;
-    }
-
-    public boolean isToday() {
-        return isToday;
-    }
-
-    public boolean isSelectable() {
-        return isSelectable;
-    }
-
-    @Override
-    protected int[] onCreateDrawableState(int extraSpace) {
-        final int[] drawableState = super.onCreateDrawableState(extraSpace + 5);
-
-        if (isSelectable) {
-            mergeDrawableStates(drawableState, STATE_SELECTABLE);
-        }
-
-        if (isCurrentMonth) {
-            mergeDrawableStates(drawableState, STATE_CURRENT_MONTH);
-        }
-
-        if (isToday) {
-            mergeDrawableStates(drawableState, STATE_TODAY);
-        }
-
-        if (isHighlighted) {
-            mergeDrawableStates(drawableState, STATE_HIGHLIGHTED);
-        }
-
-        if (rangeState == MonthCellDescriptor.RangeState.FIRST) {
-            mergeDrawableStates(drawableState, STATE_RANGE_FIRST);
-        } else if (rangeState == MonthCellDescriptor.RangeState.MIDDLE) {
-            mergeDrawableStates(drawableState, STATE_RANGE_MIDDLE);
-        } else if (rangeState == RangeState.LAST) {
-            mergeDrawableStates(drawableState, STATE_RANGE_LAST);
-        }
-
-        return drawableState;
-    }
+    return drawableState;
+  }
 }

--- a/library/src/com/squareup/timessquare/CalendarCellView.java
+++ b/library/src/com/squareup/timessquare/CalendarCellView.java
@@ -69,9 +69,9 @@ public class CalendarCellView extends TextView {
     }
   }
 
-  public void setHighlighted(boolean highlighted) {
-    if (this.isHighlighted != highlighted) {
-      isHighlighted = highlighted;
+  public void setHighlighted(boolean isHighlighted) {
+    if (this.isHighlighted != isHighlighted) {
+      this.isHighlighted = isHighlighted;
       refreshDrawableState();
     }
   }

--- a/library/src/com/squareup/timessquare/CalendarCellView.java
+++ b/library/src/com/squareup/timessquare/CalendarCellView.java
@@ -70,7 +70,7 @@ public class CalendarCellView extends TextView {
   }
 
   public void setHighlighted(boolean highlighted) {
-    if (this.isHighlighted != isHighlighted) {
+    if (this.isHighlighted != highlighted) {
       isHighlighted = highlighted;
       refreshDrawableState();
     }

--- a/library/src/com/squareup/timessquare/CalendarCellView.java
+++ b/library/src/com/squareup/timessquare/CalendarCellView.java
@@ -5,106 +5,118 @@ package com.squareup.timessquare;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.widget.TextView;
+
 import com.squareup.timessquare.MonthCellDescriptor.RangeState;
 
 public class CalendarCellView extends TextView {
-  private static final int[] STATE_SELECTABLE = {
-      R.attr.state_selectable
-  };
-  private static final int[] STATE_CURRENT_MONTH = {
-      R.attr.state_current_month
-  };
-  private static final int[] STATE_TODAY = {
-      R.attr.state_today
-  };
-  private static final int[] STATE_HIGHLIGHTED = {
-      R.attr.state_highlighted
-  };
-  private static final int[] STATE_RANGE_FIRST = {
-      R.attr.state_range_first
-  };
-  private static final int[] STATE_RANGE_MIDDLE = {
-      R.attr.state_range_middle
-  };
-  private static final int[] STATE_RANGE_LAST = {
-      R.attr.state_range_last
-  };
+    private static final int[] STATE_SELECTABLE = {
+            R.attr.state_selectable
+    };
+    private static final int[] STATE_CURRENT_MONTH = {
+            R.attr.state_current_month
+    };
+    private static final int[] STATE_TODAY = {
+            R.attr.state_today
+    };
+    private static final int[] STATE_HIGHLIGHTED = {
+            R.attr.state_highlighted
+    };
+    private static final int[] STATE_RANGE_FIRST = {
+            R.attr.state_range_first
+    };
+    private static final int[] STATE_RANGE_MIDDLE = {
+            R.attr.state_range_middle
+    };
+    private static final int[] STATE_RANGE_LAST = {
+            R.attr.state_range_last
+    };
 
-  private boolean isSelectable = false;
-  private boolean isCurrentMonth = false;
-  private boolean isToday = false;
-  private boolean isHighlighted = false;
-  private RangeState rangeState = RangeState.NONE;
+    private boolean isSelectable = false;
+    private boolean isCurrentMonth = false;
+    private boolean isToday = false;
+    private boolean isHighlighted = false;
+    private RangeState rangeState = RangeState.NONE;
 
-  @SuppressWarnings("UnusedDeclaration") //
-  public CalendarCellView(Context context, AttributeSet attrs) {
-    super(context, attrs);
-  }
-
-  public void setSelectable(boolean isSelectable) {
-    this.isSelectable = isSelectable;
-    refreshDrawableState();
-  }
-
-  public void setCurrentMonth(boolean isCurrentMonth) {
-    this.isCurrentMonth = isCurrentMonth;
-    refreshDrawableState();
-  }
-
-  public void setToday(boolean isToday) {
-    this.isToday = isToday;
-    refreshDrawableState();
-  }
-
-  public void setRangeState(MonthCellDescriptor.RangeState rangeState) {
-    this.rangeState = rangeState;
-    refreshDrawableState();
-  }
-
-  public void setHighlighted(boolean highlighted) {
-    isHighlighted = highlighted;
-    refreshDrawableState();
-  }
-
-  public boolean isCurrentMonth() {
-    return isCurrentMonth;
-  }
-
-  public boolean isToday() {
-    return isToday;
-  }
-
-  public boolean isSelectable() {
-    return isSelectable;
-  }
-
-  @Override protected int[] onCreateDrawableState(int extraSpace) {
-    final int[] drawableState = super.onCreateDrawableState(extraSpace + 5);
-
-    if (isSelectable) {
-      mergeDrawableStates(drawableState, STATE_SELECTABLE);
+    @SuppressWarnings("UnusedDeclaration") //
+    public CalendarCellView(Context context, AttributeSet attrs) {
+        super(context, attrs);
     }
 
-    if (isCurrentMonth) {
-      mergeDrawableStates(drawableState, STATE_CURRENT_MONTH);
+    public void setSelectable(boolean isSelectable) {
+        if (this.isSelectable != isSelectable) {
+            this.isSelectable = isSelectable;
+            refreshDrawableState();
+        }
     }
 
-    if (isToday) {
-      mergeDrawableStates(drawableState, STATE_TODAY);
+    public void setCurrentMonth(boolean isCurrentMonth) {
+        if (this.isCurrentMonth != isCurrentMonth) {
+            this.isCurrentMonth = isCurrentMonth;
+            refreshDrawableState();
+        }
     }
 
-    if (isHighlighted) {
-      mergeDrawableStates(drawableState, STATE_HIGHLIGHTED);
+    public void setToday(boolean isToday) {
+        if (this.isToday != isToday) {
+            this.isToday = isToday;
+            refreshDrawableState();
+        }
     }
 
-    if (rangeState == MonthCellDescriptor.RangeState.FIRST) {
-      mergeDrawableStates(drawableState, STATE_RANGE_FIRST);
-    } else if (rangeState == MonthCellDescriptor.RangeState.MIDDLE) {
-      mergeDrawableStates(drawableState, STATE_RANGE_MIDDLE);
-    } else if (rangeState == RangeState.LAST) {
-      mergeDrawableStates(drawableState, STATE_RANGE_LAST);
+    public void setRangeState(MonthCellDescriptor.RangeState rangeState) {
+        if (this.rangeState != rangeState) {
+            this.rangeState = rangeState;
+            refreshDrawableState();
+        }
     }
 
-    return drawableState;
-  }
+    public void setHighlighted(boolean highlighted) {
+        if (this.isHighlighted != highlighted) {
+            isHighlighted = highlighted;
+            refreshDrawableState();
+        }
+    }
+
+    public boolean isCurrentMonth() {
+        return isCurrentMonth;
+    }
+
+    public boolean isToday() {
+        return isToday;
+    }
+
+    public boolean isSelectable() {
+        return isSelectable;
+    }
+
+    @Override
+    protected int[] onCreateDrawableState(int extraSpace) {
+        final int[] drawableState = super.onCreateDrawableState(extraSpace + 5);
+
+        if (isSelectable) {
+            mergeDrawableStates(drawableState, STATE_SELECTABLE);
+        }
+
+        if (isCurrentMonth) {
+            mergeDrawableStates(drawableState, STATE_CURRENT_MONTH);
+        }
+
+        if (isToday) {
+            mergeDrawableStates(drawableState, STATE_TODAY);
+        }
+
+        if (isHighlighted) {
+            mergeDrawableStates(drawableState, STATE_HIGHLIGHTED);
+        }
+
+        if (rangeState == MonthCellDescriptor.RangeState.FIRST) {
+            mergeDrawableStates(drawableState, STATE_RANGE_FIRST);
+        } else if (rangeState == MonthCellDescriptor.RangeState.MIDDLE) {
+            mergeDrawableStates(drawableState, STATE_RANGE_MIDDLE);
+        } else if (rangeState == RangeState.LAST) {
+            mergeDrawableStates(drawableState, STATE_RANGE_LAST);
+        }
+
+        return drawableState;
+    }
 }


### PR DESCRIPTION
We ensure states have changed before calling refreshDrawableState() which calls the view's mergeDrawableStates method which itself makes an arraycopy. Because this can happen to a lot of views, performance gains can be quite substantial.
An even better approach would be to make sure MonthView.init only calls refreshDrawableState() once for each of its CalendarCells