### PR TITLE
Add German and Dutch translation. replaces #233

### DIFF
--- a/library/src/main/res/values-de/strings.xml
+++ b/library/src/main/res/values-de/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="invalid_date">Datum muss zwischen %1$s und %2$s fallen.</string>
+</resources>

--- a/library/src/main/res/values-nl/strings.xml
+++ b/library/src/main/res/values-nl/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="invalid_date">Datum moet vallen tussen %1$s en %2$s.</string>
+</resources>


### PR DESCRIPTION
This PR is to add a German and Dutch translation for the library. Difference with #233 is that this one leaves the translatable flags unmodified