### PR TITLE
retrieve identifier via lookup

### DIFF
--- a/library/src/main/java/com/squareup/timessquare/CalendarCellView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarCellView.java
@@ -3,32 +3,21 @@
 package com.squareup.timessquare;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.util.AttributeSet;
 import android.widget.TextView;
 import com.squareup.timessquare.MonthCellDescriptor.RangeState;
 
 public class CalendarCellView extends TextView {
-  private static final int[] STATE_SELECTABLE = {
-      R.attr.tsquare_state_selectable
-  };
-  private static final int[] STATE_CURRENT_MONTH = {
-      R.attr.tsquare_state_current_month
-  };
-  private static final int[] STATE_TODAY = {
-      R.attr.tsquare_state_today
-  };
-  private static final int[] STATE_HIGHLIGHTED = {
-      R.attr.tsquare_state_highlighted
-  };
-  private static final int[] STATE_RANGE_FIRST = {
-      R.attr.tsquare_state_range_first
-  };
-  private static final int[] STATE_RANGE_MIDDLE = {
-      R.attr.tsquare_state_range_middle
-  };
-  private static final int[] STATE_RANGE_LAST = {
-      R.attr.tsquare_state_range_last
-  };
+
+  private final int[] STATE_SELECTABLE;
+  private final int[] STATE_CURRENT_MONTH;
+  private final int[] STATE_TODAY;
+  private final int[] STATE_HIGHLIGHTED;
+  private final int[] STATE_RANGE_FIRST;
+  private final int[] STATE_RANGE_MIDDLE;
+  private final int[] STATE_RANGE_LAST;
+
 
   private boolean isSelectable = false;
   private boolean isCurrentMonth = false;
@@ -39,6 +28,18 @@ public class CalendarCellView extends TextView {
   @SuppressWarnings("UnusedDeclaration") //
   public CalendarCellView(Context context, AttributeSet attrs) {
     super(context, attrs);
+    Resources res = getResources();
+    STATE_SELECTABLE = getAttrIntArray("tsquare_state_selectable");
+    STATE_CURRENT_MONTH = getAttrIntArray("tsquare_state_current_month");
+    STATE_TODAY = getAttrIntArray("tsquare_state_today");
+    STATE_HIGHLIGHTED = getAttrIntArray("tsquare_state_highlighted");
+    STATE_RANGE_FIRST = getAttrIntArray("tsquare_state_range_first");
+    STATE_RANGE_MIDDLE = getAttrIntArray("tsquare_state_range_middle");
+    STATE_RANGE_LAST = getAttrIntArray("tsquare_state_range_last");
+  }
+
+  private int[] getAttrIntArray(String name) {
+    return new int[] {getResources().getIdentifier(name, "attr", getContext().getPackageName())};
   }
 
   public void setSelectable(boolean isSelectable) {

--- a/library/src/main/java/com/squareup/timessquare/CalendarGridView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarGridView.java
@@ -31,7 +31,8 @@ public class CalendarGridView extends ViewGroup {
 
   public CalendarGridView(Context context, AttributeSet attrs) {
     super(context, attrs);
-    dividerPaint.setColor(getResources().getColor(R.color.calendar_divider));
+    int colorId = getResources().getIdentifier("calendar_divider", "color", context.getPackageName());
+    dividerPaint.setColor(getResources().getColor(colorId));
   }
 
   public void setDividerColor(int color) {

--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -42,6 +42,8 @@ import static java.util.Calendar.YEAR;
  * {@link #getSelectedDate()}.
  */
 public class CalendarPickerView extends ListView {
+
+
   public enum SelectionMode {
     /**
      * Only one date will be selectable.  If there is already a selected date and you select a new
@@ -94,6 +96,8 @@ public class CalendarPickerView extends ListView {
       new DefaultOnInvalidDateSelectedListener();
   private CellClickInterceptor cellClickInterceptor;
   private List<CalendarCellDecorator> decorators;
+  private final Context ctx;
+  private final Resources res;
 
   public void setDecorators(List<CalendarCellDecorator> decorators) {
     this.decorators = decorators;
@@ -108,22 +112,22 @@ public class CalendarPickerView extends ListView {
 
   public CalendarPickerView(Context context, AttributeSet attrs) {
     super(context, attrs);
-
-    Resources res = context.getResources();
+    ctx = context;
+    res = context.getResources();
     TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.CalendarPickerView);
     final int bg = a.getColor(R.styleable.CalendarPickerView_android_background,
-        res.getColor(R.color.calendar_bg));
+        getColor("calendar_bg"));
     dividerColor = a.getColor(R.styleable.CalendarPickerView_tsquare_dividerColor,
-        res.getColor(R.color.calendar_divider));
+            getColor("calendar_divider"));
     dayBackgroundResId = a.getResourceId(R.styleable.CalendarPickerView_tsquare_dayBackground,
-        R.drawable.calendar_bg_selector);
+            getDrawableId("calendar_bg_selector"));
     dayTextColorResId = a.getResourceId(R.styleable.CalendarPickerView_tsquare_dayTextColor,
-        R.color.calendar_text_selector);
+            getColorId("calendar_text_selector"));
     titleTextColor = a.getColor(R.styleable.CalendarPickerView_tsquare_titleTextColor,
-        res.getColor(R.color.calendar_text_active));
+            getColor("calendar_text_active"));
     displayHeader = a.getBoolean(R.styleable.CalendarPickerView_tsquare_displayHeader, true);
     headerTextColor = a.getColor(R.styleable.CalendarPickerView_tsquare_headerTextColor,
-        res.getColor(R.color.calendar_text_active));
+            getColor("calendar_text_active"));
     a.recycle();
 
     adapter = new MonthAdapter();
@@ -136,8 +140,8 @@ public class CalendarPickerView extends ListView {
     minCal = Calendar.getInstance(locale);
     maxCal = Calendar.getInstance(locale);
     monthCounter = Calendar.getInstance(locale);
-    monthNameFormat = new SimpleDateFormat(context.getString(R.string.month_name_format), locale);
-    weekdayNameFormat = new SimpleDateFormat(context.getString(R.string.day_name_format), locale);
+    monthNameFormat = new SimpleDateFormat(getString("month_name_format"), locale);
+    weekdayNameFormat = new SimpleDateFormat(getString("day_name_format"), locale);
     fullDateFormat = DateFormat.getDateInstance(DateFormat.MEDIUM, locale);
 
     if (isInEditMode()) {
@@ -147,6 +151,22 @@ public class CalendarPickerView extends ListView {
       init(new Date(), nextYear.getTime()) //
           .withSelectedDate(new Date());
     }
+  }
+
+  private int getDrawableId(String name) {
+    return res.getIdentifier(name, "drawable", ctx.getPackageName());
+  }
+
+  private int getColor(String name) {
+    return res.getColor(getColorId(name));
+  }
+
+  private int getColorId(String name) {
+    return res.getIdentifier(name, "color", ctx.getPackageName());
+  }
+
+  private String getString(String name) {
+    return res.getString(res.getIdentifier(name, "string", ctx.getPackageName()));
   }
 
   /**
@@ -186,12 +206,12 @@ public class CalendarPickerView extends ListView {
     maxCal = Calendar.getInstance(locale);
     monthCounter = Calendar.getInstance(locale);
     monthNameFormat =
-        new SimpleDateFormat(getContext().getString(R.string.month_name_format), locale);
+        new SimpleDateFormat(getString("month_name_format"), locale);
     for (MonthDescriptor month : months) {
       month.setLabel(monthNameFormat.format(month.getDate()));
     }
     weekdayNameFormat =
-        new SimpleDateFormat(getContext().getString(R.string.day_name_format), locale);
+        new SimpleDateFormat(getString("day_name_format"), locale);
     fullDateFormat = DateFormat.getDateInstance(DateFormat.MEDIUM, locale);
 
     this.selectionMode = SelectionMode.SINGLE;
@@ -308,7 +328,7 @@ public class CalendarPickerView extends ListView {
       DateFormatSymbols symbols = new DateFormatSymbols(locale);
       symbols.setShortWeekdays(newShortWeekdays);
       weekdayNameFormat =
-          new SimpleDateFormat(getContext().getString(R.string.day_name_format), symbols);
+          new SimpleDateFormat(getString("day_name_format"), symbols);
       return this;
     }
 
@@ -947,7 +967,7 @@ public class CalendarPickerView extends ListView {
   private class DefaultOnInvalidDateSelectedListener implements OnInvalidDateSelectedListener {
     @Override public void onInvalidDateSelected(Date date) {
       String errMessage =
-          getResources().getString(R.string.invalid_date, fullDateFormat.format(minCal.getTime()),
+          getResources().getString(getResources().getIdentifier("invalid_date", "string", getContext().getPackageName()), fullDateFormat.format(minCal.getTime()),
               fullDateFormat.format(maxCal.getTime()));
       Toast.makeText(getContext(), errMessage, Toast.LENGTH_SHORT).show();
     }

--- a/library/src/main/java/com/squareup/timessquare/MonthView.java
+++ b/library/src/main/java/com/squareup/timessquare/MonthView.java
@@ -2,6 +2,7 @@
 package com.squareup.timessquare;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.Typeface;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -33,7 +34,7 @@ public class MonthView extends LinearLayout {
       DateFormat weekdayNameFormat, Listener listener, Calendar today, int dividerColor,
       int dayBackgroundResId, int dayTextColorResId, int titleTextColor, boolean displayHeader,
       int headerTextColor, List<CalendarCellDecorator> decorators, Locale locale) {
-    final MonthView view = (MonthView) inflater.inflate(R.layout.month, parent, false);
+    final MonthView view = (MonthView) inflater.inflate(getLayoutId(inflater.getContext(), "month"), parent, false);
     view.setDividerColor(dividerColor);
     view.setDayTextColor(dayTextColorResId);
     view.setTitleTextColor(titleTextColor);
@@ -58,6 +59,11 @@ public class MonthView extends LinearLayout {
     view.listener = listener;
     view.decorators = decorators;
     return view;
+  }
+
+  private static int getLayoutId(Context ctx, String name) {
+    Resources res = ctx.getResources();
+    return res.getIdentifier(name, "layout", ctx.getPackageName());
   }
 
   private static int getDayOfWeek(int firstDayOfWeek, int offset, boolean isRtl) {
@@ -89,8 +95,12 @@ public class MonthView extends LinearLayout {
 
   @Override protected void onFinishInflate() {
     super.onFinishInflate();
-    title = (TextView) findViewById(R.id.title);
-    grid = (CalendarGridView) findViewById(R.id.calendar_grid);
+    title = (TextView) findViewById(getIdentifier("title"));
+    grid = (CalendarGridView) findViewById(getIdentifier("calendar_grid"));
+  }
+
+  private int getIdentifier(String name) {
+    return getResources().getIdentifier(name, "id", getContext().getPackageName());
   }
 
   public void init(MonthDescriptor month, List<List<MonthCellDescriptor>> cells,


### PR DESCRIPTION
Libraries should access identifiers via lookup to avoid clashes with other libraries, that are updated. 
But maybe that's not necessary with the Gradle build system. If so, close this request. 