### PR TITLE
Feature/custom layouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build
 out
 lib
 
+local.properties
 release.properties
 
 .idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ after_success:
 
 env:
   global:
-    - secure: "jpcnT7u80SX1SngObG41hZ0OarA3bje69YAV9t8daYCtNpu/RHoNjYhBmpCBZoEuL0zst7r5CmTkFSAf/V7CXnuUaYfeKCPo1LLZDBYIGgUYutGSJ1JkEby3eytek4HevG8hsjMOrhdQT27qyZ3ESNvW8JgpLd/R06/64SLbhWM="
-    - secure: "paXM9hwEIfdDo25fxLlVj9UbKPBx5HvOz/ehRr150SBxY9XhwXV3PkcII483vlmYiSE0yKKanSf5CDpteV1wRnQPUxF4QzyXmcwiDektV6ld7/qHRXWeZ89Bt3S8GZ5MEZSDhF6cmq5Ivi6v/5gvlobnTw1Vp55idbJZ94EdE7g="
+    - secure: "mokP2uluF4Yeg7ZvhjVOoo6E5lXWWyhhqGMZ4EbZ3xbl8W/a6oObwoLkVhxaMpdFz597VfBdiC0wX+y9ri2HBY2g2CCf2B4FFNsPFzA9MAKchFwfeqd/Z5GxfZVvEdYdSSueIRpeNJnjVVxt3WApCtNn7wsu9j3P4AtD76KxGL0="
+    - secure: "nfVaFnrXdHiPWjArMUFO9+5OX/jIKcUrue+xXDg1rNlVsevuGMC+DMBfOGgHBAITD1Vsp0XRWrvzVFntLoigZ4rMBbNvt0dBRPhlr49CqxIFwKw/kAcDqbNjvMpOvvghOqqNNW2HDzLvIiy2G93ZNz+p+DkcYTT8mi7d1UFhKqQ="
 
 branches:
   except:

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ You can also depend on the library through Maven:
 <dependency>
   <groupId>com.squareup</groupId>
   <artifactId>android-times-square</artifactId>
-  <version>1.5.0</version>
+  <version>1.6.4</version>
   <type>apklib</type>
 </dependency>
 ```
 or Gradle:
 ```groovy
-compile 'com.squareup:android-times-square:1.5.0@aar'
+compile 'com.squareup:android-times-square:1.6.4@aar'
 ```
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].

--- a/library/src/main/java/com/squareup/timessquare/CalendarCellView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarCellView.java
@@ -4,10 +4,11 @@ package com.squareup.timessquare;
 
 import android.content.Context;
 import android.util.AttributeSet;
+import android.widget.FrameLayout;
 import android.widget.TextView;
 import com.squareup.timessquare.MonthCellDescriptor.RangeState;
 
-public class CalendarCellView extends TextView {
+public class CalendarCellView extends FrameLayout {
   private static final int[] STATE_SELECTABLE = {
       R.attr.tsquare_state_selectable
   };
@@ -35,6 +36,7 @@ public class CalendarCellView extends TextView {
   private boolean isToday = false;
   private boolean isHighlighted = false;
   private RangeState rangeState = RangeState.NONE;
+  private TextView dayOfMonthTextView;
 
   @SuppressWarnings("UnusedDeclaration") //
   public CalendarCellView(Context context, AttributeSet attrs) {
@@ -106,5 +108,18 @@ public class CalendarCellView extends TextView {
     }
 
     return drawableState;
+  }
+
+  public void setDayOfMonthTextView(TextView textView) {
+    dayOfMonthTextView = textView;
+  }
+
+  public TextView getDayOfMonthTextView() {
+    if (dayOfMonthTextView == null) {
+      throw new IllegalStateException(
+              "You have to setDayOfMonthTextView in your custom DayViewAdapter."
+      );
+    }
+    return dayOfMonthTextView;
   }
 }

--- a/library/src/main/java/com/squareup/timessquare/CalendarGridView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarGridView.java
@@ -38,6 +38,12 @@ public class CalendarGridView extends ViewGroup {
     dividerPaint.setColor(color);
   }
 
+  public void setDayViewAdapter(DayViewAdapter adapter) {
+    for (int i = 0; i < getChildCount(); i++) {
+      ((CalendarRowView) getChildAt(i)).setDayViewAdapter(adapter);
+    }
+  }
+
   public void setDayBackground(int resId) {
     for (int i = 1; i < getChildCount(); i++) {
       ((CalendarRowView) getChildAt(i)).setCellBackground(resId);

--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -95,6 +95,7 @@ public class CalendarPickerView extends ListView {
       new DefaultOnInvalidDateSelectedListener();
   private CellClickInterceptor cellClickInterceptor;
   private List<CalendarCellDecorator> decorators;
+  private DayViewAdapter dayViewAdapter = new DefaultDayViewAdapter();
 
   public void setDecorators(List<CalendarCellDecorator> decorators) {
     this.decorators = decorators;
@@ -753,11 +754,13 @@ public class CalendarPickerView extends ListView {
 
     @Override public View getView(int position, View convertView, ViewGroup parent) {
       MonthView monthView = (MonthView) convertView;
-      if (monthView == null) {
+      if (monthView == null
+             || !monthView.getTag(R.id.day_view_adapter_class).equals(dayViewAdapter.getClass())) {
         monthView =
             MonthView.create(parent, inflater, weekdayNameFormat, listener, today, dividerColor,
                 dayBackgroundResId, dayTextColorResId, titleTextColor, displayHeader,
-                headerTextColor, decorators, locale);
+                headerTextColor, decorators, locale, dayViewAdapter);
+        monthView.setTag(R.id.day_view_adapter_class, dayViewAdapter.getClass());
       } else {
         monthView.setDecorators(decorators);
       }
@@ -895,6 +898,20 @@ public class CalendarPickerView extends ListView {
    */
   public void setDateSelectableFilter(DateSelectableFilter listener) {
     dateConfiguredListener = listener;
+  }
+
+
+  /**
+   * Set an adapter used to initialize {@link CalendarCellView} with custom layout.
+   * <p>
+   * Important: set this before you call {@link #init(Date, Date)} methods.  If called afterwards,
+   * it will not be consistently applied.
+   */
+  public void setCustomDayView(DayViewAdapter dayViewAdapter) {
+    this.dayViewAdapter = dayViewAdapter;
+    if (null != adapter) {
+      adapter.notifyDataSetChanged();
+    }
   }
 
   /** Set a listener to intercept clicks on calendar cells. */

--- a/library/src/main/java/com/squareup/timessquare/CalendarRowView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarRowView.java
@@ -79,6 +79,16 @@ public class CalendarRowView extends ViewGroup implements View.OnClickListener {
     this.listener = listener;
   }
 
+  public void setDayViewAdapter(DayViewAdapter adapter) {
+    for (int i = 0; i < getChildCount(); i++) {
+      if (getChildAt(i) instanceof CalendarCellView) {
+        CalendarCellView cell = ((CalendarCellView) getChildAt(i));
+        cell.removeAllViews();
+        adapter.makeCellView(cell);
+      }
+    }
+  }
+
   public void setCellBackground(int resId) {
     for (int i = 0; i < getChildCount(); i++) {
       getChildAt(i).setBackgroundResource(resId);
@@ -87,19 +97,31 @@ public class CalendarRowView extends ViewGroup implements View.OnClickListener {
 
   public void setCellTextColor(int resId) {
     for (int i = 0; i < getChildCount(); i++) {
-      ((TextView) getChildAt(i)).setTextColor(resId);
+      if (getChildAt(i) instanceof CalendarCellView) {
+        ((CalendarCellView) getChildAt(i)).getDayOfMonthTextView().setTextColor(resId);
+      } else {
+        ((TextView) getChildAt(i)).setTextColor(resId);
+      }
     }
   }
 
   public void setCellTextColor(ColorStateList colors) {
     for (int i = 0; i < getChildCount(); i++) {
-      ((TextView) getChildAt(i)).setTextColor(colors);
+      if (getChildAt(i) instanceof CalendarCellView) {
+        ((CalendarCellView) getChildAt(i)).getDayOfMonthTextView().setTextColor(colors);
+      } else {
+        ((TextView) getChildAt(i)).setTextColor(colors);
+      }
     }
   }
 
   public void setTypeface(Typeface typeface) {
     for (int i = 0; i < getChildCount(); i++) {
-      ((TextView) getChildAt(i)).setTypeface(typeface);
+      if (getChildAt(i) instanceof CalendarCellView) {
+        ((CalendarCellView) getChildAt(i)).getDayOfMonthTextView().setTypeface(typeface);
+      } else {
+        ((TextView) getChildAt(i)).setTypeface(typeface);
+      }
     }
   }
 }

--- a/library/src/main/java/com/squareup/timessquare/DayViewAdapter.java
+++ b/library/src/main/java/com/squareup/timessquare/DayViewAdapter.java
@@ -1,0 +1,6 @@
+package com.squareup.timessquare;
+
+/** Adapter used to provide a layout for {@link CalendarCellView}.*/
+public interface DayViewAdapter {
+  void makeCellView(CalendarCellView parent);
+}

--- a/library/src/main/java/com/squareup/timessquare/DefaultDayViewAdapter.java
+++ b/library/src/main/java/com/squareup/timessquare/DefaultDayViewAdapter.java
@@ -1,0 +1,15 @@
+package com.squareup.timessquare;
+
+import android.view.ContextThemeWrapper;
+import android.widget.TextView;
+
+public class DefaultDayViewAdapter implements DayViewAdapter {
+  @Override
+  public void makeCellView(CalendarCellView parent) {
+      TextView textView = new TextView(
+              new ContextThemeWrapper(parent.getContext(), R.style.CalendarCell_CalendarDate));
+      textView.setDuplicateParentStateEnabled(true);
+      parent.addView(textView);
+      parent.setDayOfMonthTextView(textView);
+  }
+}

--- a/library/src/main/java/com/squareup/timessquare/MonthView.java
+++ b/library/src/main/java/com/squareup/timessquare/MonthView.java
@@ -23,17 +23,19 @@ public class MonthView extends LinearLayout {
   public static MonthView create(ViewGroup parent, LayoutInflater inflater,
       DateFormat weekdayNameFormat, Listener listener, Calendar today, int dividerColor,
       int dayBackgroundResId, int dayTextColorResId, int titleTextColor, boolean displayHeader,
-      int headerTextColor, Locale locale) {
+      int headerTextColor, Locale locale, DayViewAdapter adapter) {
     return create(parent, inflater, weekdayNameFormat, listener, today, dividerColor,
         dayBackgroundResId, dayTextColorResId, titleTextColor, displayHeader, headerTextColor, null,
-        locale);
+        locale, adapter);
   }
 
   public static MonthView create(ViewGroup parent, LayoutInflater inflater,
       DateFormat weekdayNameFormat, Listener listener, Calendar today, int dividerColor,
       int dayBackgroundResId, int dayTextColorResId, int titleTextColor, boolean displayHeader,
-      int headerTextColor, List<CalendarCellDecorator> decorators, Locale locale) {
+      int headerTextColor, List<CalendarCellDecorator> decorators, Locale locale,
+      DayViewAdapter adapter) {
     final MonthView view = (MonthView) inflater.inflate(R.layout.month, parent, false);
+    view.setDayViewAdapter(adapter);
     view.setDividerColor(dividerColor);
     view.setDayTextColor(dayTextColorResId);
     view.setTitleTextColor(titleTextColor);
@@ -112,8 +114,8 @@ public class MonthView extends LinearLayout {
           CalendarCellView cellView = (CalendarCellView) weekRow.getChildAt(c);
 
           String cellDate = Integer.toString(cell.getValue());
-          if (!cellView.getText().equals(cellDate)) {
-            cellView.setText(cellDate);
+          if (!cellView.getDayOfMonthTextView().getText().equals(cellDate)) {
+            cellView.getDayOfMonthTextView().setText(cellDate);
           }
           cellView.setEnabled(cell.isCurrentMonth());
           cellView.setClickable(!displayOnly);
@@ -157,6 +159,10 @@ public class MonthView extends LinearLayout {
 
   public void setDayTextColor(int resId) {
     grid.setDayTextColor(resId);
+  }
+
+  public void setDayViewAdapter(DayViewAdapter adapter) {
+    grid.setDayViewAdapter(adapter);
   }
 
   public void setTitleTextColor(int color) {

--- a/library/src/main/res/layout/week.xml
+++ b/library/src/main/res/layout/week.xml
@@ -8,36 +8,29 @@
   <com.squareup.timessquare.CalendarCellView
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      style="@style/CalendarCell.CalendarDate"
       />
   <com.squareup.timessquare.CalendarCellView
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      style="@style/CalendarCell.CalendarDate"
       />
   <com.squareup.timessquare.CalendarCellView
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      style="@style/CalendarCell.CalendarDate"
       />
   <com.squareup.timessquare.CalendarCellView
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      style="@style/CalendarCell.CalendarDate"
       />
   <com.squareup.timessquare.CalendarCellView
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      style="@style/CalendarCell.CalendarDate"
       />
   <com.squareup.timessquare.CalendarCellView
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      style="@style/CalendarCell.CalendarDate"
       />
   <com.squareup.timessquare.CalendarCellView
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      style="@style/CalendarCell.CalendarDate"
       />
 </com.squareup.timessquare.CalendarRowView>

--- a/library/src/main/res/values-pl/strings.xml
+++ b/library/src/main/res/values-pl/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2015 Square, Inc. -->
+
+<resources>
+  <string name="invalid_date">Data musi znaleźć się między %1$s a %2$s.</string>
+</resources>

--- a/library/src/main/res/values/ids.xml
+++ b/library/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item type="id" name="day_view_adapter_class"/>
+</resources>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -18,7 +18,6 @@
 
   <style name="CalendarCell.CalendarDate">
     <item name="android:textSize">@dimen/calendar_text_medium</item>
-    <item name="android:clickable">true</item>
     <item name="android:textStyle">bold</item>
   </style>
 </resources>

--- a/library/src/test/java/com/squareup/timessquare/CalendarPickerViewTest.java
+++ b/library/src/test/java/com/squareup/timessquare/CalendarPickerViewTest.java
@@ -564,10 +564,10 @@ public class CalendarPickerViewTest {
     TextView firstDay = (TextView) header.getChildAt(0);
     assertThat(firstDay).hasTextString("ש"); // Last day of the week (Saturday) is the first cell.
     CalendarRowView firstWeek = (CalendarRowView) monthView.grid.getChildAt(1);
-    TextView firstDate = (TextView) firstWeek.getChildAt(0);
+    TextView firstDate = ((CalendarCellView) firstWeek.getChildAt(0)).getDayOfMonthTextView();
     assertThat(firstDate).hasTextString("1");
     CalendarRowView secondWeek = (CalendarRowView) monthView.grid.getChildAt(2);
-    TextView secondDate = (TextView) secondWeek.getChildAt(6);
+    TextView secondDate = ((CalendarCellView) secondWeek.getChildAt(6)).getDayOfMonthTextView();
     assertThat(secondDate).hasTextString("2");
     assertThat(monthView.title).hasTextString("דצמבר 2012");
   }

--- a/sample/src/main/java/com/squareup/timessquare/sample/SampleDayViewAdapter.java
+++ b/sample/src/main/java/com/squareup/timessquare/sample/SampleDayViewAdapter.java
@@ -1,0 +1,17 @@
+package com.squareup.timessquare.sample;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.TextView;
+
+import com.squareup.timessquare.CalendarCellView;
+import com.squareup.timessquare.DayViewAdapter;
+
+public class SampleDayViewAdapter implements DayViewAdapter {
+  @Override
+  public void makeCellView(CalendarCellView parent) {
+      View layout = LayoutInflater.from(parent.getContext()).inflate(R.layout.day_view_custom, null);
+      parent.addView(layout);
+      parent.setDayOfMonthTextView((TextView) layout.findViewById(R.id.day_view));
+  }
+}

--- a/sample/src/main/java/com/squareup/timessquare/sample/SampleDecorator.java
+++ b/sample/src/main/java/com/squareup/timessquare/sample/SampleDecorator.java
@@ -14,6 +14,6 @@ public class SampleDecorator implements CalendarCellDecorator {
     SpannableString string = new SpannableString(dateString + "\ntitle");
     string.setSpan(new RelativeSizeSpan(0.5f), 0, dateString.length(),
         Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-    cellView.setText(string);
+    cellView.getDayOfMonthTextView().setText(string);
   }
 }

--- a/sample/src/main/java/com/squareup/timessquare/sample/SampleTimesSquareActivity.java
+++ b/sample/src/main/java/com/squareup/timessquare/sample/SampleTimesSquareActivity.java
@@ -13,6 +13,8 @@ import android.widget.Toast;
 import com.squareup.timessquare.CalendarCellDecorator;
 import com.squareup.timessquare.CalendarPickerView;
 import com.squareup.timessquare.CalendarPickerView.SelectionMode;
+import com.squareup.timessquare.DefaultDayViewAdapter;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -58,13 +60,15 @@ public class SampleTimesSquareActivity extends Activity {
     final Button customized = (Button) findViewById(R.id.button_customized);
     final Button decorator = (Button) findViewById(R.id.button_decorator);
     final Button rtl = (Button) findViewById(R.id.button_rtl);
+    final Button customView = (Button) findViewById(R.id.button_custom_view);
 
-    modeButtons.addAll(Arrays.asList(single, multi, range, displayOnly, decorator));
+    modeButtons.addAll(Arrays.asList(single, multi, range, displayOnly, decorator, customView));
 
     single.setOnClickListener(new OnClickListener() {
       @Override public void onClick(View v) {
         setButtonsEnabled(single);
 
+        calendar.setCustomDayView(new DefaultDayViewAdapter());
         calendar.setDecorators(Collections.<CalendarCellDecorator>emptyList());
         calendar.init(lastYear.getTime(), nextYear.getTime()) //
             .inMode(SelectionMode.SINGLE) //
@@ -76,6 +80,7 @@ public class SampleTimesSquareActivity extends Activity {
       @Override public void onClick(View v) {
         setButtonsEnabled(multi);
 
+        calendar.setCustomDayView(new DefaultDayViewAdapter());
         Calendar today = Calendar.getInstance();
         ArrayList<Date> dates = new ArrayList<Date>();
         for (int i = 0; i < 5; i++) {
@@ -93,6 +98,7 @@ public class SampleTimesSquareActivity extends Activity {
       @Override public void onClick(View v) {
         setButtonsEnabled(range);
 
+        calendar.setCustomDayView(new DefaultDayViewAdapter());
         Calendar today = Calendar.getInstance();
         ArrayList<Date> dates = new ArrayList<Date>();
         today.add(Calendar.DATE, 3);
@@ -110,6 +116,7 @@ public class SampleTimesSquareActivity extends Activity {
       @Override public void onClick(View v) {
         setButtonsEnabled(displayOnly);
 
+        calendar.setCustomDayView(new DefaultDayViewAdapter());
         calendar.setDecorators(Collections.<CalendarCellDecorator>emptyList());
         calendar.init(new Date(), nextYear.getTime()) //
             .inMode(SelectionMode.SINGLE) //
@@ -139,6 +146,7 @@ public class SampleTimesSquareActivity extends Activity {
       @Override public void onClick(View v) {
         setButtonsEnabled(decorator);
 
+        calendar.setCustomDayView(new DefaultDayViewAdapter());
         calendar.setDecorators(Arrays.<CalendarCellDecorator>asList(new SampleDecorator()));
         calendar.init(lastYear.getTime(), nextYear.getTime()) //
             .inMode(SelectionMode.SINGLE) //
@@ -150,7 +158,19 @@ public class SampleTimesSquareActivity extends Activity {
       @Override public void onClick(View view) {
         showCalendarInDialog("I'm right-to-left!", R.layout.dialog);
         dialogView.init(lastYear.getTime(), nextYear.getTime(), new Locale("iw", "IL")) //
-            .withSelectedDate(new Date());
+                .withSelectedDate(new Date());
+      }
+    });
+
+    customView.setOnClickListener(new OnClickListener() {
+      @Override public void onClick(View view) {
+        setButtonsEnabled(customView);
+
+        calendar.setDecorators(Collections.<CalendarCellDecorator>emptyList());
+        calendar.setCustomDayView(new SampleDayViewAdapter());
+        calendar.init(lastYear.getTime(), nextYear.getTime())
+                .inMode(SelectionMode.SINGLE)
+                .withSelectedDate(new Date());
       }
     });
 

--- a/sample/src/main/res/layout/day_view_custom.xml
+++ b/sample/src/main/res/layout/day_view_custom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="4dp"
+    >
+
+    <TextView
+        android:id="@+id/day_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        style="@style/CalendarCell.CalendarDate"/>
+
+    <ImageView
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:src="@drawable/icon"
+        android:scaleType="centerInside"/>
+</LinearLayout>

--- a/sample/src/main/res/layout/sample_calendar_picker.xml
+++ b/sample/src/main/res/layout/sample_calendar_picker.xml
@@ -64,6 +64,12 @@
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:text="@string/RTL"/>
+
+      <Button
+          android:id="@+id/button_custom_view"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/CustomView"/>
     </LinearLayout>
   </HorizontalScrollView>
 

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="Customized">Customized</string>
     <string name="Decorator">Decorator</string>
     <string name="RTL">RTL</string>
+    <string name="CustomView">Custom View</string>
     <string name="Dialog">Dialog</string>
     <string name="DisplayOnly">DisplayOnly</string>
     <string name="Range">Range</string>


### PR DESCRIPTION
The existing decorator pattern for composing custom day view wasn't enough for my needs. I wanted a custom layout where I could add e.g. an ImageView. I implemented it changing the CalendarCellView from TextView to FrameLayout and making a DayViewAdapter which can be used (via setCustomDayView) to inflate custom layout in lieu of the TextView. There is also a default implementation of this adapter, so that the basic experience doesn't change. I also added new sample.

I would like to go even further. E.g. make the default square cells optional so I can make layouts like this: https://s3-eu-west-1.amazonaws.com/uploads-eu.hipchat.com/83322/1764739/LfK3hqFNB2x1yQG/3.0%20Booking%402x.png. But I want to hear your thoughts first.