### PR TITLE
Exposing a text color property for highlighted state

### DIFF
--- a/library/src/main/res/color/calendar_text_selector.xml
+++ b/library/src/main/res/color/calendar_text_selector.xml
@@ -6,6 +6,7 @@
   <item android:state_selected="true" android:color="@color/calendar_text_selected"/>
   <item android:state_pressed="true" android:color="@color/calendar_text_selected"/>
   <item app:tsquare_state_current_month="false" android:color="@color/calendar_text_inactive"/>
+  <item app:tsquare_state_highlighted="true" android:color="@color/calendar_text_highlighted" />
   <item app:tsquare_state_today="true" android:color="@color/calendar_active_month_bg"/>
   <item app:tsquare_state_selectable="false" android:color="@color/calendar_text_unselectable" />
   <item android:color="@color/calendar_text_active"/>

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -11,4 +11,5 @@
   <color name="calendar_text_active">#ff778088</color>
   <color name="calendar_text_selected">#ffffffff</color>
   <color name="calendar_text_unselectable">#7f778088</color>
+  <color name="calendar_text_highlighted">#ff778088</color>
 </resources>


### PR DESCRIPTION
This patch just exposes a text color property for highlighted state. I left the color the same as the active color which is the current color it defaults to when highlighted.