### PR TITLE
allow_1_day_range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Version 1.7.1 *(2017-01-13)*
+----------------------------
+
+ * New: Added ability to select 1 date in range mode (for return trips etc)
+
 Version 1.7.0 *(2016-10-26)*
 ----------------------------
 

--- a/library/src/main/java/com/squareup/timessquare/CalendarCellView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarCellView.java
@@ -30,6 +30,9 @@ public class CalendarCellView extends FrameLayout {
   private static final int[] STATE_RANGE_LAST = {
       R.attr.tsquare_state_range_last
   };
+  private static final int[] STATE_RANGE_FIRST_AND_LAST = {
+      R.attr.tsquare_state_range_first_and_last
+  };
 
   private boolean isSelectable = false;
   private boolean isCurrentMonth = false;
@@ -123,6 +126,8 @@ public class CalendarCellView extends FrameLayout {
       mergeDrawableStates(drawableState, STATE_RANGE_MIDDLE);
     } else if (rangeState == RangeState.LAST) {
       mergeDrawableStates(drawableState, STATE_RANGE_LAST);
+    } else if (rangeState == RangeState.FIRST_AND_LAST) {
+      mergeDrawableStates(drawableState, STATE_RANGE_FIRST_AND_LAST);
     }
 
     return drawableState;

--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -658,7 +658,8 @@ public class CalendarPickerView extends ListView {
 
     if (date != null) {
       // Select a new cell.
-      if (selectedCells.size() == 0 || !selectedCells.get(0).equals(cell)) {
+      if (selectedCells.size() == 0 || !selectedCells.get(0).equals(cell)
+            || (selectionMode == SelectionMode.RANGE && selectedCells.get(0).equals(cell))) {
         selectedCells.add(cell);
         cell.setSelected(true);
       }
@@ -668,8 +669,13 @@ public class CalendarPickerView extends ListView {
         // Select all days in between start and end.
         Date start = selectedCells.get(0).getDate();
         Date end = selectedCells.get(1).getDate();
-        selectedCells.get(0).setRangeState(MonthCellDescriptor.RangeState.FIRST);
-        selectedCells.get(1).setRangeState(MonthCellDescriptor.RangeState.LAST);
+        if (start.before(end)) {
+          selectedCells.get(0).setRangeState(MonthCellDescriptor.RangeState.FIRST);
+          selectedCells.get(1).setRangeState(MonthCellDescriptor.RangeState.LAST);
+        } else if (start.compareTo(end) == 0) {
+          selectedCells.remove(selectedCells.size() - 1);
+          selectedCells.get(0).setRangeState(MonthCellDescriptor.RangeState.FIRST_AND_LAST);
+        }
 
         for (List<List<MonthCellDescriptor>> month : cells) {
           for (List<MonthCellDescriptor> week : month) {
@@ -868,9 +874,11 @@ public class CalendarPickerView extends ListView {
 
         MonthCellDescriptor.RangeState rangeState = MonthCellDescriptor.RangeState.NONE;
         if (selectedCals.size() > 1) {
-          if (sameDate(minSelectedCal, cal)) {
+          if (sameDate(minSelectedCal, cal) && sameDate(maxSelectedCal, cal)) {
+            rangeState = MonthCellDescriptor.RangeState.FIRST_AND_LAST;
+          } else if (sameDate(minSelectedCal, cal)) {
             rangeState = MonthCellDescriptor.RangeState.FIRST;
-          } else if (sameDate(maxDate(selectedCals), cal)) {
+          } else if (sameDate(maxSelectedCal, cal)) {
             rangeState = MonthCellDescriptor.RangeState.LAST;
           } else if (betweenDates(cal, minSelectedCal, maxSelectedCal)) {
             rangeState = MonthCellDescriptor.RangeState.MIDDLE;

--- a/library/src/main/java/com/squareup/timessquare/MonthCellDescriptor.java
+++ b/library/src/main/java/com/squareup/timessquare/MonthCellDescriptor.java
@@ -7,7 +7,7 @@ import java.util.Date;
 /** Describes the state of a particular date cell in a {@link MonthView}. */
 class MonthCellDescriptor {
   public enum RangeState {
-    NONE, FIRST, MIDDLE, LAST
+    NONE, FIRST, MIDDLE, LAST, FIRST_AND_LAST
   }
 
   private final Date date;

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -17,6 +17,7 @@
     <attr name="tsquare_state_range_first" format="boolean" />
     <attr name="tsquare_state_range_middle" format="boolean" />
     <attr name="tsquare_state_range_last" format="boolean" />
+    <attr name="tsquare_state_range_first_and_last" format="boolean" />
     <attr name="tsquare_state_highlighted" format="boolean" />
   </declare-styleable>
 </resources>

--- a/library/src/test/java/com/squareup/timessquare/CalendarPickerViewTest.java
+++ b/library/src/test/java/com/squareup/timessquare/CalendarPickerViewTest.java
@@ -23,6 +23,7 @@ import static com.squareup.timessquare.CalendarPickerView.SelectionMode.MULTIPLE
 import static com.squareup.timessquare.CalendarPickerView.SelectionMode.RANGE;
 import static com.squareup.timessquare.CalendarPickerView.SelectionMode.SINGLE;
 import static com.squareup.timessquare.MonthCellDescriptor.RangeState.FIRST;
+import static com.squareup.timessquare.MonthCellDescriptor.RangeState.FIRST_AND_LAST;
 import static com.squareup.timessquare.MonthCellDescriptor.RangeState.LAST;
 import static com.squareup.timessquare.MonthCellDescriptor.RangeState.MIDDLE;
 import static com.squareup.timessquare.MonthCellDescriptor.RangeState.NONE;
@@ -494,6 +495,13 @@ public class CalendarPickerViewTest {
     view.selectDate(nov24.getTime());
     assertOneDateSelected();
 
+    // Finish that range with same date.
+    Calendar sameDay = buildCal(2012, NOVEMBER, 24);
+    view.selectDate(sameDay.getTime());
+    assertThat(view.selectedCals).hasSize(2);
+    assertThat(view.selectedCells).hasSize(1);
+    assertThat(view.getSelectedDates()).hasSize(1);
+
     // Only Nov 24 is selected: going backward should start a new range.
     view.selectDate(nov20.getTime());
     assertOneDateSelected();
@@ -560,6 +568,23 @@ public class CalendarPickerViewTest {
     assertCell(cells, 3, 4, 22, true, false, false, true, MIDDLE);
     assertCell(cells, 3, 5, 23, true, false, false, true, MIDDLE);
     assertCell(cells, 3, 6, 24, true, true, false, true, LAST);
+  }
+
+  @Test public void testRangeStateForSameDateSelection() {
+    Calendar startCal = buildCal(2012, NOVEMBER, 17);
+    Calendar endCal = buildCal(2012, NOVEMBER, 17);
+
+    view.init(minDate, maxDate, timeZone, locale) //
+        .inMode(RANGE);
+
+    boolean wasAbleToSetDate = view.selectDate(startCal.getTime());
+    assertThat(wasAbleToSetDate).isTrue();
+
+    wasAbleToSetDate = view.selectDate(endCal.getTime());
+    assertThat(wasAbleToSetDate).isTrue();
+
+    List<List<MonthCellDescriptor>> cells = getCells(NOVEMBER, 2012);
+    assertCell(cells, 2, 6, 17, true, true, false, true, FIRST_AND_LAST);
   }
 
   @Test public void testLocaleSetting() throws Exception {

--- a/sample/src/main/java/com/squareup/timessquare/sample/SampleTimesSquareActivity.java
+++ b/sample/src/main/java/com/squareup/timessquare/sample/SampleTimesSquareActivity.java
@@ -139,6 +139,7 @@ public class SampleTimesSquareActivity extends Activity {
       @Override public void onClick(View view) {
         showCalendarInDialog("Pimp my calendar!", R.layout.dialog_customized);
         dialogView.init(lastYear.getTime(), nextYear.getTime())
+            .inMode(SelectionMode.RANGE)
             .withSelectedDate(new Date());
       }
     });

--- a/sample/src/main/res/drawable/bg_circle_first_and_last.xml
+++ b/sample/src/main/res/drawable/bg_circle_first_and_last.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <solid android:color="@color/custom_background"/>
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="@color/custom_background_first_and_last"/>
+            <stroke android:width="@dimen/dimen_margin_circle"
+                    android:color="@color/transparent"/>
+        </shape>
+    </item>
+</layer-list>

--- a/sample/src/main/res/drawable/custom_calendar_bg_selector.xml
+++ b/sample/src/main/res/drawable/custom_calendar_bg_selector.xml
@@ -2,6 +2,7 @@
 
 <selector xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item app:tsquare_state_range_first_and_last="true" android:drawable="@drawable/bg_circle_first_and_last"/>
     <item android:state_selected="true" android:drawable="@drawable/bg_circle_selected"/>
     <item android:state_pressed="true" android:drawable="@drawable/bg_circle_selected"/>
     <item app:tsquare_state_current_month="false">

--- a/sample/src/main/res/values/colors.xml
+++ b/sample/src/main/res/values/colors.xml
@@ -5,6 +5,7 @@
     <color name="custom_background">#F0F8DB</color>
     <color name="custom_background_today">#FF9105</color>
     <color name="custom_background_disabled">#F0F8DB</color>
+    <color name="custom_background_first_and_last">#555fff</color>
     <color name="custom_text_selected">#FFFFFFFF</color>
     <color name="custom_text_inactive">#7f778088</color>
     <color name="transparent">#00000000</color>


### PR DESCRIPTION
* Modified some logic to allow users to select 1 day as a range as this may be useful in travel dates (for return etc)
* Added new attribute to allow for different drawables/colors for use with new rangeState
* Added some unit tests for testing same date selection and rangeState
* Updated sample app to display changes