### PR TITLE
Move RangeState up to top level and make public.

### DIFF
--- a/library/src/main/java/com/squareup/timessquare/CalendarCellView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarCellView.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.widget.FrameLayout;
 import android.widget.TextView;
-import com.squareup.timessquare.MonthCellDescriptor.RangeState;
 
 public class CalendarCellView extends FrameLayout {
   private static final int[] STATE_SELECTABLE = {
@@ -64,7 +63,7 @@ public class CalendarCellView extends FrameLayout {
     }
   }
 
-  public void setRangeState(MonthCellDescriptor.RangeState rangeState) {
+  public void setRangeState(RangeState rangeState) {
     if (this.rangeState != rangeState) {
       this.rangeState = rangeState;
       refreshDrawableState();
@@ -117,9 +116,9 @@ public class CalendarCellView extends FrameLayout {
       mergeDrawableStates(drawableState, STATE_HIGHLIGHTED);
     }
 
-    if (rangeState == MonthCellDescriptor.RangeState.FIRST) {
+    if (rangeState == RangeState.FIRST) {
       mergeDrawableStates(drawableState, STATE_RANGE_FIRST);
-    } else if (rangeState == MonthCellDescriptor.RangeState.MIDDLE) {
+    } else if (rangeState == RangeState.MIDDLE) {
       mergeDrawableStates(drawableState, STATE_RANGE_MIDDLE);
     } else if (rangeState == RangeState.LAST) {
       mergeDrawableStates(drawableState, STATE_RANGE_LAST);

--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -13,7 +13,6 @@ import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.ListView;
 import android.widget.Toast;
-import com.squareup.timessquare.MonthCellDescriptor.RangeState;
 import java.text.DateFormat;
 import java.text.DateFormatSymbols;
 import java.text.SimpleDateFormat;
@@ -669,8 +668,8 @@ public class CalendarPickerView extends ListView {
         // Select all days in between start and end.
         Date start = selectedCells.get(0).getDate();
         Date end = selectedCells.get(1).getDate();
-        selectedCells.get(0).setRangeState(MonthCellDescriptor.RangeState.FIRST);
-        selectedCells.get(1).setRangeState(MonthCellDescriptor.RangeState.LAST);
+        selectedCells.get(0).setRangeState(RangeState.FIRST);
+        selectedCells.get(1).setRangeState(RangeState.LAST);
 
         int startMonthIndex = cells.getIndexOfKey(monthKey(selectedCals.get(0)));
         int endMonthIndex = cells.getIndexOfKey(monthKey(selectedCals.get(1)));
@@ -682,7 +681,7 @@ public class CalendarPickerView extends ListView {
                   && singleCell.getDate().before(end)
                   && singleCell.isSelectable()) {
                 singleCell.setSelected(true);
-                singleCell.setRangeState(MonthCellDescriptor.RangeState.MIDDLE);
+                singleCell.setRangeState(RangeState.MIDDLE);
                 selectedCells.add(singleCell);
               }
             }
@@ -886,14 +885,14 @@ public class CalendarPickerView extends ListView {
         boolean isHighlighted = containsDate(highlightedCals, cal);
         int value = cal.get(DAY_OF_MONTH);
 
-        MonthCellDescriptor.RangeState rangeState = MonthCellDescriptor.RangeState.NONE;
+        RangeState rangeState = RangeState.NONE;
         if (selectedCals.size() > 1) {
           if (sameDate(minSelectedCal, cal)) {
-            rangeState = MonthCellDescriptor.RangeState.FIRST;
+            rangeState = RangeState.FIRST;
           } else if (sameDate(maxDate(selectedCals), cal)) {
-            rangeState = MonthCellDescriptor.RangeState.LAST;
+            rangeState = RangeState.LAST;
           } else if (betweenDates(cal, minSelectedCal, maxSelectedCal)) {
-            rangeState = MonthCellDescriptor.RangeState.MIDDLE;
+            rangeState = RangeState.MIDDLE;
           }
         }
 

--- a/library/src/main/java/com/squareup/timessquare/MonthCellDescriptor.java
+++ b/library/src/main/java/com/squareup/timessquare/MonthCellDescriptor.java
@@ -6,9 +6,6 @@ import java.util.Date;
 
 /** Describes the state of a particular date cell in a {@link MonthView}. */
 class MonthCellDescriptor {
-  public enum RangeState {
-    NONE, FIRST, MIDDLE, LAST
-  }
 
   private final Date date;
   private final int value;

--- a/library/src/main/java/com/squareup/timessquare/RangeState.java
+++ b/library/src/main/java/com/squareup/timessquare/RangeState.java
@@ -1,0 +1,6 @@
+package com.squareup.timessquare;
+
+/** The range state of a cell for {@link MonthCellDescriptor} and {@link CalendarCellView}*/
+public enum RangeState {
+    NONE, FIRST, MIDDLE, LAST
+}

--- a/library/src/test/java/com/squareup/timessquare/CalendarPickerViewTest.java
+++ b/library/src/test/java/com/squareup/timessquare/CalendarPickerViewTest.java
@@ -22,10 +22,10 @@ import org.robolectric.annotation.Config;
 import static com.squareup.timessquare.CalendarPickerView.SelectionMode.MULTIPLE;
 import static com.squareup.timessquare.CalendarPickerView.SelectionMode.RANGE;
 import static com.squareup.timessquare.CalendarPickerView.SelectionMode.SINGLE;
-import static com.squareup.timessquare.MonthCellDescriptor.RangeState.FIRST;
-import static com.squareup.timessquare.MonthCellDescriptor.RangeState.LAST;
-import static com.squareup.timessquare.MonthCellDescriptor.RangeState.MIDDLE;
-import static com.squareup.timessquare.MonthCellDescriptor.RangeState.NONE;
+import static com.squareup.timessquare.RangeState.FIRST;
+import static com.squareup.timessquare.RangeState.LAST;
+import static com.squareup.timessquare.RangeState.MIDDLE;
+import static com.squareup.timessquare.RangeState.NONE;
 import static java.util.Calendar.APRIL;
 import static java.util.Calendar.AUGUST;
 import static java.util.Calendar.DATE;
@@ -433,7 +433,7 @@ public class CalendarPickerViewTest {
     jumpToCal.add(DATE, 1);
     MonthCellDescriptor cellToClick =
         new MonthCellDescriptor(jumpToCal.getTime(), true, true, true, true, true, 0,
-            MonthCellDescriptor.RangeState.NONE);
+            RangeState.NONE);
     view.listener.handleClick(cellToClick);
 
     assertThat(view.selectedCals.get(0).get(DATE)).isEqualTo(jumpToCal.get(DATE));
@@ -639,14 +639,14 @@ public class CalendarPickerViewTest {
     jumpToCal.set(DAY_OF_MONTH, 17);
     MonthCellDescriptor cellToClick =
         new MonthCellDescriptor(jumpToCal.getTime(), true, true, true, true, true, 0,
-            MonthCellDescriptor.RangeState.NONE);
+            RangeState.NONE);
     view.listener.handleClick(cellToClick);
 
     assertThat(view.selectedCals.get(0).get(DATE)).isEqualTo(17);
 
     jumpToCal.set(DAY_OF_MONTH, 18);
     cellToClick = new MonthCellDescriptor(jumpToCal.getTime(), true, true, true, true, true, 0,
-        MonthCellDescriptor.RangeState.NONE);
+        RangeState.NONE);
     view.listener.handleClick(cellToClick);
 
     assertThat(view.selectedCals.get(0).get(DATE)).isEqualTo(17);
@@ -678,7 +678,7 @@ public class CalendarPickerViewTest {
   private static void assertCell(List<List<MonthCellDescriptor>> cells, int row, int col,
       int expectedVal, boolean expectedCurrentMonth, boolean expectedSelected,
       boolean expectedToday, boolean expectedSelectable,
-      MonthCellDescriptor.RangeState expectedRangeState) {
+      RangeState expectedRangeState) {
     final MonthCellDescriptor cell = cells.get(row).get(col);
     assertThat(cell.getValue()).isEqualTo(expectedVal);
     assertThat(cell.isCurrentMonth()).isEqualTo(expectedCurrentMonth);


### PR DESCRIPTION
Moved RangeState and made public so getRangeState() can be used on CalendarCellView without having to use .ordinal().