### PR TITLE
Add option to display months in reverse order

### DIFF
--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -106,14 +106,6 @@ public class CalendarPickerView extends ListView {
     }
   }
 
-  public boolean isMonthsReverseOrder() {
-    return monthsReverseOrder;
-  }
-
-  public void setMonthsReverseOrder(boolean monthsReverseOrder) {
-    this.monthsReverseOrder = monthsReverseOrder;
-  }
-
   public List<CalendarCellDecorator> getDecorators() {
     return decorators;
   }
@@ -864,7 +856,7 @@ public class CalendarPickerView extends ListView {
       } else {
         monthView.setDecorators(decorators);
       }
-      if (isMonthsReverseOrder()) {
+      if (monthsReverseOrder) {
         position = months.size() - position - 1;
       }
       monthView.init(months.get(position), cells.getValueAtIndex(position), displayOnly,

--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -114,7 +114,6 @@ public class CalendarPickerView extends ListView {
     this.monthsReverseOrder = monthsReverseOrder;
   }
 
-
   public List<CalendarCellDecorator> getDecorators() {
     return decorators;
   }
@@ -137,8 +136,6 @@ public class CalendarPickerView extends ListView {
     displayHeader = a.getBoolean(R.styleable.CalendarPickerView_tsquare_displayHeader, true);
     headerTextColor = a.getColor(R.styleable.CalendarPickerView_tsquare_headerTextColor,
         res.getColor(R.color.calendar_text_active));
-    monthsReverseOrder = a.getBoolean(R.styleable.CalendarPickerView_tsquare_monthsReverseOrder,
-            false);
     a.recycle();
 
     adapter = new MonthAdapter();
@@ -396,6 +393,11 @@ public class CalendarPickerView extends ListView {
 
     public FluentInitializer displayOnly() {
       displayOnly = true;
+      return this;
+    }
+
+    public FluentInitializer withMonthsReverseOrder(boolean monthsRevOrder) {
+      monthsReverseOrder = monthsRevOrder;
       return this;
     }
   }

--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -97,12 +97,23 @@ public class CalendarPickerView extends ListView {
   private List<CalendarCellDecorator> decorators;
   private DayViewAdapter dayViewAdapter = new DefaultDayViewAdapter();
 
+  private boolean monthsReverseOrder;
+
   public void setDecorators(List<CalendarCellDecorator> decorators) {
     this.decorators = decorators;
     if (null != adapter) {
       adapter.notifyDataSetChanged();
     }
   }
+
+  public boolean isMonthsReverseOrder() {
+    return monthsReverseOrder;
+  }
+
+  public void setMonthsReverseOrder(boolean monthsReverseOrder) {
+    this.monthsReverseOrder = monthsReverseOrder;
+  }
+
 
   public List<CalendarCellDecorator> getDecorators() {
     return decorators;
@@ -126,6 +137,8 @@ public class CalendarPickerView extends ListView {
     displayHeader = a.getBoolean(R.styleable.CalendarPickerView_tsquare_displayHeader, true);
     headerTextColor = a.getColor(R.styleable.CalendarPickerView_tsquare_headerTextColor,
         res.getColor(R.color.calendar_text_active));
+    monthsReverseOrder = a.getBoolean(R.styleable.CalendarPickerView_tsquare_monthsReverseOrder,
+            false);
     a.recycle();
 
     adapter = new MonthAdapter();
@@ -848,6 +861,9 @@ public class CalendarPickerView extends ListView {
         monthView.setTag(R.id.day_view_adapter_class, dayViewAdapter.getClass());
       } else {
         monthView.setDecorators(decorators);
+      }
+      if (isMonthsReverseOrder()) {
+        position = months.size() - position - 1;
       }
       monthView.init(months.get(position), cells.getValueAtIndex(position), displayOnly,
           titleTypeface, dateTypeface);

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -8,7 +8,6 @@
     <attr name="tsquare_titleTextColor" format="color"/>
     <attr name="tsquare_displayHeader" format="boolean"/>
     <attr name="tsquare_headerTextColor" format="color"/>
-    <attr name="tsquare_monthsReverseOrder" format="boolean"/>
   </declare-styleable>
 
   <declare-styleable name="calendar_cell">

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -8,6 +8,7 @@
     <attr name="tsquare_titleTextColor" format="color"/>
     <attr name="tsquare_displayHeader" format="boolean"/>
     <attr name="tsquare_headerTextColor" format="color"/>
+    <attr name="tsquare_monthsReverseOrder" format="boolean"/>
   </declare-styleable>
 
   <declare-styleable name="calendar_cell">


### PR DESCRIPTION
Sometimes app design requires to display months in reverse order which is quite problematic, because of private adapter class. StackFromBottom only scrolls to the end of the list by default, not reversing order.