### PR TITLE
Ability to hide the week view via xml attribute

### DIFF
--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -86,7 +86,7 @@ public class CalendarPickerView extends ListView {
   private int titleTextColor;
   private boolean displayHeader;
   private int headerTextColor;
-  private boolean displayWeekView;
+  private boolean displayDayNamesHeaderRow;
   private Typeface titleTypeface;
   private Typeface dateTypeface;
 
@@ -129,7 +129,8 @@ public class CalendarPickerView extends ListView {
     displayHeader = a.getBoolean(R.styleable.CalendarPickerView_tsquare_displayHeader, true);
     headerTextColor = a.getColor(R.styleable.CalendarPickerView_tsquare_headerTextColor,
         res.getColor(R.color.calendar_text_active));
-    displayWeekView = a.getBoolean(R.styleable.CalendarPickerView_tsquare_displayWeekView, true);
+    displayDayNamesHeaderRow =
+            a.getBoolean(R.styleable.CalendarPickerView_tsquare_displayDayNamesHeaderRow, true);
     a.recycle();
 
     adapter = new MonthAdapter();
@@ -853,7 +854,7 @@ public class CalendarPickerView extends ListView {
         monthView =
             MonthView.create(parent, inflater, weekdayNameFormat, listener, today, dividerColor,
                 dayBackgroundResId, dayTextColorResId, titleTextColor, displayHeader,
-                headerTextColor, displayWeekView, decorators, locale, dayViewAdapter);
+                headerTextColor, displayDayNamesHeaderRow, decorators, locale, dayViewAdapter);
         monthView.setTag(R.id.day_view_adapter_class, dayViewAdapter.getClass());
       } else {
         monthView.setDecorators(decorators);

--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -86,6 +86,7 @@ public class CalendarPickerView extends ListView {
   private int titleTextColor;
   private boolean displayHeader;
   private int headerTextColor;
+  private boolean displayWeekView;
   private Typeface titleTypeface;
   private Typeface dateTypeface;
 
@@ -128,6 +129,7 @@ public class CalendarPickerView extends ListView {
     displayHeader = a.getBoolean(R.styleable.CalendarPickerView_tsquare_displayHeader, true);
     headerTextColor = a.getColor(R.styleable.CalendarPickerView_tsquare_headerTextColor,
         res.getColor(R.color.calendar_text_active));
+    displayWeekView = a.getBoolean(R.styleable.CalendarPickerView_tsquare_displayWeekView, true);
     a.recycle();
 
     adapter = new MonthAdapter();
@@ -851,7 +853,7 @@ public class CalendarPickerView extends ListView {
         monthView =
             MonthView.create(parent, inflater, weekdayNameFormat, listener, today, dividerColor,
                 dayBackgroundResId, dayTextColorResId, titleTextColor, displayHeader,
-                headerTextColor, decorators, locale, dayViewAdapter);
+                headerTextColor, displayWeekView, decorators, locale, dayViewAdapter);
         monthView.setTag(R.id.day_view_adapter_class, dayViewAdapter.getClass());
       } else {
         monthView.setDecorators(decorators);

--- a/library/src/main/java/com/squareup/timessquare/MonthView.java
+++ b/library/src/main/java/com/squareup/timessquare/MonthView.java
@@ -103,7 +103,7 @@ public class MonthView extends LinearLayout {
     super.onFinishInflate();
     title = (TextView) findViewById(R.id.title);
     grid = (CalendarGridView) findViewById(R.id.calendar_grid);
-    weekView = findViewById(R.id.week_row_view);
+    weekView = findViewById(R.id.day_names_header_row);
   }
 
   public void init(MonthDescriptor month, List<List<MonthCellDescriptor>> cells,

--- a/library/src/main/java/com/squareup/timessquare/MonthView.java
+++ b/library/src/main/java/com/squareup/timessquare/MonthView.java
@@ -18,7 +18,7 @@ import java.util.Locale;
 public class MonthView extends LinearLayout {
   TextView title;
   CalendarGridView grid;
-  View weekView;
+  View dayNamesHeaderRowView;
   private Listener listener;
   private List<CalendarCellDecorator> decorators;
   private boolean isRtl;
@@ -27,10 +27,11 @@ public class MonthView extends LinearLayout {
   public static MonthView create(ViewGroup parent, LayoutInflater inflater,
       DateFormat weekdayNameFormat, Listener listener, Calendar today, int dividerColor,
       int dayBackgroundResId, int dayTextColorResId, int titleTextColor, boolean displayHeader,
-      int headerTextColor, boolean showWeekView, Locale locale, DayViewAdapter adapter) {
+      int headerTextColor, boolean showDayNamesHeaderRowView, Locale locale,
+      DayViewAdapter adapter) {
     return create(parent, inflater, weekdayNameFormat, listener, today, dividerColor,
         dayBackgroundResId, dayTextColorResId, titleTextColor, displayHeader, headerTextColor,
-        showWeekView, null, locale, adapter);
+        showDayNamesHeaderRowView, null, locale, adapter);
   }
 
   public static MonthView create(ViewGroup parent, LayoutInflater inflater,
@@ -64,7 +65,7 @@ public class MonthView extends LinearLayout {
       }
       today.set(Calendar.DAY_OF_WEEK, originalDayOfWeek);
     } else {
-      view.weekView.setVisibility(View.GONE);
+      view.dayNamesHeaderRowView.setVisibility(View.GONE);
     }
 
     view.listener = listener;
@@ -103,7 +104,7 @@ public class MonthView extends LinearLayout {
     super.onFinishInflate();
     title = (TextView) findViewById(R.id.title);
     grid = (CalendarGridView) findViewById(R.id.calendar_grid);
-    weekView = findViewById(R.id.day_names_header_row);
+    dayNamesHeaderRowView = findViewById(R.id.day_names_header_row);
   }
 
   public void init(MonthDescriptor month, List<List<MonthCellDescriptor>> cells,

--- a/library/src/main/java/com/squareup/timessquare/MonthView.java
+++ b/library/src/main/java/com/squareup/timessquare/MonthView.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.graphics.Typeface;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -17,6 +18,7 @@ import java.util.Locale;
 public class MonthView extends LinearLayout {
   TextView title;
   CalendarGridView grid;
+  View weekView;
   private Listener listener;
   private List<CalendarCellDecorator> decorators;
   private boolean isRtl;
@@ -25,16 +27,16 @@ public class MonthView extends LinearLayout {
   public static MonthView create(ViewGroup parent, LayoutInflater inflater,
       DateFormat weekdayNameFormat, Listener listener, Calendar today, int dividerColor,
       int dayBackgroundResId, int dayTextColorResId, int titleTextColor, boolean displayHeader,
-      int headerTextColor, Locale locale, DayViewAdapter adapter) {
+      int headerTextColor, boolean showWeekView, Locale locale, DayViewAdapter adapter) {
     return create(parent, inflater, weekdayNameFormat, listener, today, dividerColor,
-        dayBackgroundResId, dayTextColorResId, titleTextColor, displayHeader, headerTextColor, null,
-        locale, adapter);
+        dayBackgroundResId, dayTextColorResId, titleTextColor, displayHeader, headerTextColor,
+        showWeekView, null, locale, adapter);
   }
 
   public static MonthView create(ViewGroup parent, LayoutInflater inflater,
       DateFormat weekdayNameFormat, Listener listener, Calendar today, int dividerColor,
       int dayBackgroundResId, int dayTextColorResId, int titleTextColor, boolean displayHeader,
-      int headerTextColor, List<CalendarCellDecorator> decorators, Locale locale,
+      int headerTextColor, boolean displayWeekView, List<CalendarCellDecorator> decorators, Locale locale,
       DayViewAdapter adapter) {
     final MonthView view = (MonthView) inflater.inflate(R.layout.month, parent, false);
     view.setDayViewAdapter(adapter);
@@ -48,18 +50,23 @@ public class MonthView extends LinearLayout {
       view.setDayBackground(dayBackgroundResId);
     }
 
-    final int originalDayOfWeek = today.get(Calendar.DAY_OF_WEEK);
-
     view.isRtl = isRtl(locale);
     view.locale = locale;
     int firstDayOfWeek = today.getFirstDayOfWeek();
     final CalendarRowView headerRow = (CalendarRowView) view.grid.getChildAt(0);
-    for (int offset = 0; offset < 7; offset++) {
-      today.set(Calendar.DAY_OF_WEEK, getDayOfWeek(firstDayOfWeek, offset, view.isRtl));
-      final TextView textView = (TextView) headerRow.getChildAt(offset);
-      textView.setText(weekdayNameFormat.format(today.getTime()));
+
+    if (displayWeekView) {
+      final int originalDayOfWeek = today.get(Calendar.DAY_OF_WEEK);
+      for (int offset = 0; offset < 7; offset++) {
+        today.set(Calendar.DAY_OF_WEEK, getDayOfWeek(firstDayOfWeek, offset, view.isRtl));
+        final TextView textView = (TextView) headerRow.getChildAt(offset);
+        textView.setText(weekdayNameFormat.format(today.getTime()));
+      }
+      today.set(Calendar.DAY_OF_WEEK, originalDayOfWeek);
+    } else {
+      view.weekView.setVisibility(View.GONE);
     }
-    today.set(Calendar.DAY_OF_WEEK, originalDayOfWeek);
+
     view.listener = listener;
     view.decorators = decorators;
     return view;
@@ -96,6 +103,7 @@ public class MonthView extends LinearLayout {
     super.onFinishInflate();
     title = (TextView) findViewById(R.id.title);
     grid = (CalendarGridView) findViewById(R.id.calendar_grid);
+    weekView = findViewById(R.id.week_row_view);
   }
 
   public void init(MonthDescriptor month, List<List<MonthCellDescriptor>> cells,

--- a/library/src/main/java/com/squareup/timessquare/MonthView.java
+++ b/library/src/main/java/com/squareup/timessquare/MonthView.java
@@ -36,8 +36,8 @@ public class MonthView extends LinearLayout {
   public static MonthView create(ViewGroup parent, LayoutInflater inflater,
       DateFormat weekdayNameFormat, Listener listener, Calendar today, int dividerColor,
       int dayBackgroundResId, int dayTextColorResId, int titleTextColor, boolean displayHeader,
-      int headerTextColor, boolean displayWeekView, List<CalendarCellDecorator> decorators, Locale locale,
-      DayViewAdapter adapter) {
+      int headerTextColor, boolean displayWeekView, List<CalendarCellDecorator> decorators,
+      Locale locale, DayViewAdapter adapter) {
     final MonthView view = (MonthView) inflater.inflate(R.layout.month, parent, false);
     view.setDayViewAdapter(adapter);
     view.setDividerColor(dividerColor);

--- a/library/src/main/java/com/squareup/timessquare/MonthView.java
+++ b/library/src/main/java/com/squareup/timessquare/MonthView.java
@@ -37,8 +37,8 @@ public class MonthView extends LinearLayout {
   public static MonthView create(ViewGroup parent, LayoutInflater inflater,
       DateFormat weekdayNameFormat, Listener listener, Calendar today, int dividerColor,
       int dayBackgroundResId, int dayTextColorResId, int titleTextColor, boolean displayHeader,
-      int headerTextColor, boolean displayWeekView, List<CalendarCellDecorator> decorators,
-      Locale locale, DayViewAdapter adapter) {
+      int headerTextColor, boolean displayDayNamesHeaderRowView,
+      List<CalendarCellDecorator> decorators, Locale locale, DayViewAdapter adapter) {
     final MonthView view = (MonthView) inflater.inflate(R.layout.month, parent, false);
     view.setDayViewAdapter(adapter);
     view.setDividerColor(dividerColor);
@@ -56,7 +56,7 @@ public class MonthView extends LinearLayout {
     int firstDayOfWeek = today.getFirstDayOfWeek();
     final CalendarRowView headerRow = (CalendarRowView) view.grid.getChildAt(0);
 
-    if (displayWeekView) {
+    if (displayDayNamesHeaderRowView) {
       final int originalDayOfWeek = today.get(Calendar.DAY_OF_WEEK);
       for (int offset = 0; offset < 7; offset++) {
         today.set(Calendar.DAY_OF_WEEK, getDayOfWeek(firstDayOfWeek, offset, view.isRtl));

--- a/library/src/main/res/layout/month.xml
+++ b/library/src/main/res/layout/month.xml
@@ -21,7 +21,7 @@
       android:layout_height="wrap_content"
       >
     <com.squareup.timessquare.CalendarRowView
-        android:id="@+id/week_row_view"
+        android:id="@+id/day_names_header_row"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingBottom="@dimen/calendar_day_headers_paddingbottom"

--- a/library/src/main/res/layout/month.xml
+++ b/library/src/main/res/layout/month.xml
@@ -21,6 +21,7 @@
       android:layout_height="wrap_content"
       >
     <com.squareup.timessquare.CalendarRowView
+        android:id="@+id/week_row_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingBottom="@dimen/calendar_day_headers_paddingbottom"

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -7,6 +7,7 @@
     <attr name="tsquare_dayTextColor" format="color"/>
     <attr name="tsquare_titleTextColor" format="color"/>
     <attr name="tsquare_displayHeader" format="boolean"/>
+    <attr name="tsquare_displayWeekView" format="boolean"/>
     <attr name="tsquare_headerTextColor" format="color"/>
   </declare-styleable>
 

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -7,7 +7,7 @@
     <attr name="tsquare_dayTextColor" format="color"/>
     <attr name="tsquare_titleTextColor" format="color"/>
     <attr name="tsquare_displayHeader" format="boolean"/>
-    <attr name="tsquare_displayWeekView" format="boolean"/>
+    <attr name="tsquare_displayDayNamesHeaderRow" format="boolean"/>
     <attr name="tsquare_headerTextColor" format="color"/>
   </declare-styleable>
 

--- a/sample/src/main/res/layout/dialog_customized.xml
+++ b/sample/src/main/res/layout/dialog_customized.xml
@@ -12,6 +12,7 @@
     android:scrollbarStyle="outsideOverlay"
     app:tsquare_dayBackground="@drawable/custom_calendar_bg_selector"
     app:tsquare_dayTextColor="@color/custom_calendar_text_selector"
+    app:tsquare_displayWeekView="false"
     app:tsquare_dividerColor="@color/transparent"
     app:tsquare_headerTextColor="@color/custom_header_text"
     app:tsquare_titleTextColor="@color/custom_calendar_text_selector"

--- a/sample/src/main/res/layout/dialog_customized.xml
+++ b/sample/src/main/res/layout/dialog_customized.xml
@@ -12,7 +12,7 @@
     android:scrollbarStyle="outsideOverlay"
     app:tsquare_dayBackground="@drawable/custom_calendar_bg_selector"
     app:tsquare_dayTextColor="@color/custom_calendar_text_selector"
-    app:tsquare_displayWeekView="false"
+    app:tsquare_displayDayNamesHeaderRow="false"
     app:tsquare_dividerColor="@color/transparent"
     app:tsquare_headerTextColor="@color/custom_header_text"
     app:tsquare_titleTextColor="@color/custom_calendar_text_selector"


### PR DESCRIPTION
Basically just added an XML attribute called 

**tsquare_day_names_header_row** *(that has a default value of true)*

which allows the library to hide the day names header row view.

This is how it looks on the custom dialog view:

<img width="317" alt="screen shot 2017-09-28 at 23 16 08" src="https://user-images.githubusercontent.com/6641413/30990952-5ca7c0aa-a4a3-11e7-86fd-af0492368c73.png">

It was implemented to achieve a day names header row view outside of the calendar. Like the following:

<img width="317" alt="screen shot 2017-09-28 at 23 16 08" src="https://user-images.githubusercontent.com/6641413/30990976-75cd2002-a4a3-11e7-8f5f-bb439b288c37.jpeg">


