### PR TITLE
Support style in month title

### DIFF
--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -83,7 +83,7 @@ public class CalendarPickerView extends ListView {
   private int dividerColor;
   private int dayBackgroundResId;
   private int dayTextColorResId;
-  private int titleTextColor;
+  private int titleTextStyle;
   private boolean displayHeader;
   private int headerTextColor;
   private boolean displayDayNamesHeaderRow;
@@ -124,8 +124,8 @@ public class CalendarPickerView extends ListView {
         R.drawable.calendar_bg_selector);
     dayTextColorResId = a.getResourceId(R.styleable.CalendarPickerView_tsquare_dayTextColor,
         R.color.calendar_text_selector);
-    titleTextColor = a.getColor(R.styleable.CalendarPickerView_tsquare_titleTextColor,
-        res.getColor(R.color.calendar_text_active));
+    titleTextStyle = a.getResourceId(R.styleable.CalendarPickerView_tsquare_titleTextStyle,
+        R.style.CalendarTitle);
     displayHeader = a.getBoolean(R.styleable.CalendarPickerView_tsquare_displayHeader, true);
     headerTextColor = a.getColor(R.styleable.CalendarPickerView_tsquare_headerTextColor,
         res.getColor(R.color.calendar_text_active));
@@ -853,7 +853,7 @@ public class CalendarPickerView extends ListView {
           || !monthView.getTag(R.id.day_view_adapter_class).equals(dayViewAdapter.getClass())) {
         monthView =
             MonthView.create(parent, inflater, weekdayNameFormat, listener, today, dividerColor,
-                dayBackgroundResId, dayTextColorResId, titleTextColor, displayHeader,
+                dayBackgroundResId, dayTextColorResId, titleTextStyle, displayHeader,
                 headerTextColor, displayDayNamesHeaderRow, decorators, locale, dayViewAdapter);
         monthView.setTag(R.id.day_view_adapter_class, dayViewAdapter.getClass());
       } else {

--- a/library/src/main/java/com/squareup/timessquare/MonthView.java
+++ b/library/src/main/java/com/squareup/timessquare/MonthView.java
@@ -4,6 +4,7 @@ package com.squareup.timessquare;
 import android.content.Context;
 import android.graphics.Typeface;
 import android.util.AttributeSet;
+import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -26,24 +27,31 @@ public class MonthView extends LinearLayout {
 
   public static MonthView create(ViewGroup parent, LayoutInflater inflater,
       DateFormat weekdayNameFormat, Listener listener, Calendar today, int dividerColor,
-      int dayBackgroundResId, int dayTextColorResId, int titleTextColor, boolean displayHeader,
+      int dayBackgroundResId, int dayTextColorResId, int titleTextStyle, boolean displayHeader,
       int headerTextColor, boolean showDayNamesHeaderRowView, Locale locale,
       DayViewAdapter adapter) {
     return create(parent, inflater, weekdayNameFormat, listener, today, dividerColor,
-        dayBackgroundResId, dayTextColorResId, titleTextColor, displayHeader, headerTextColor,
+        dayBackgroundResId, dayTextColorResId, titleTextStyle, displayHeader, headerTextColor,
         showDayNamesHeaderRowView, null, locale, adapter);
   }
 
   public static MonthView create(ViewGroup parent, LayoutInflater inflater,
       DateFormat weekdayNameFormat, Listener listener, Calendar today, int dividerColor,
-      int dayBackgroundResId, int dayTextColorResId, int titleTextColor, boolean displayHeader,
+      int dayBackgroundResId, int dayTextColorResId, int titleTextStyle, boolean displayHeader,
       int headerTextColor, boolean displayDayNamesHeaderRowView,
       List<CalendarCellDecorator> decorators, Locale locale, DayViewAdapter adapter) {
     final MonthView view = (MonthView) inflater.inflate(R.layout.month, parent, false);
+
+    // Set the views
+    view.title = new TextView(new ContextThemeWrapper(view.getContext(), titleTextStyle));
+    view.grid = (CalendarGridView) view.findViewById(R.id.calendar_grid);
+    view.dayNamesHeaderRowView = view.findViewById(R.id.day_names_header_row);
+
+    view.addView(view.title, 0);
+
     view.setDayViewAdapter(adapter);
     view.setDividerColor(dividerColor);
     view.setDayTextColor(dayTextColorResId);
-    view.setTitleTextColor(titleTextColor);
     view.setDisplayHeader(displayHeader);
     view.setHeaderTextColor(headerTextColor);
 
@@ -98,13 +106,6 @@ public class MonthView extends LinearLayout {
 
   public List<CalendarCellDecorator> getDecorators() {
     return decorators;
-  }
-
-  @Override protected void onFinishInflate() {
-    super.onFinishInflate();
-    title = (TextView) findViewById(R.id.title);
-    grid = (CalendarGridView) findViewById(R.id.calendar_grid);
-    dayNamesHeaderRowView = findViewById(R.id.day_names_header_row);
   }
 
   public void init(MonthDescriptor month, List<List<MonthCellDescriptor>> cells,
@@ -176,10 +177,6 @@ public class MonthView extends LinearLayout {
 
   public void setDayViewAdapter(DayViewAdapter adapter) {
     grid.setDayViewAdapter(adapter);
-  }
-
-  public void setTitleTextColor(int color) {
-    title.setTextColor(color);
   }
 
   public void setDisplayHeader(boolean displayHeader) {

--- a/library/src/main/java/com/squareup/timessquare/MonthView.java
+++ b/library/src/main/java/com/squareup/timessquare/MonthView.java
@@ -47,6 +47,7 @@ public class MonthView extends LinearLayout {
     view.grid = (CalendarGridView) view.findViewById(R.id.calendar_grid);
     view.dayNamesHeaderRowView = view.findViewById(R.id.day_names_header_row);
 
+    // Add the month title as the first child of MonthView
     view.addView(view.title, 0);
 
     view.setDayViewAdapter(adapter);

--- a/library/src/main/res/layout/month.xml
+++ b/library/src/main/res/layout/month.xml
@@ -6,15 +6,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     >
-  <TextView
-      android:id="@+id/title"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="@dimen/calendar_month_topmargin"
-      android:layout_marginBottom="@dimen/calendar_month_title_bottommargin"
-      android:gravity="center_horizontal"
-      style="@style/CalendarTitle"
-      />
   <com.squareup.timessquare.CalendarGridView
       android:id="@+id/calendar_grid"
       android:layout_width="match_parent"

--- a/library/src/main/res/layout/month.xml
+++ b/library/src/main/res/layout/month.xml
@@ -6,6 +6,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     >
+
+  <!-- This is the place where the month title is added -->
+
   <com.squareup.timessquare.CalendarGridView
       android:id="@+id/calendar_grid"
       android:layout_width="match_parent"

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -5,7 +5,7 @@
     <attr name="tsquare_dividerColor" format="color"/>
     <attr name="tsquare_dayBackground" format="reference"/>
     <attr name="tsquare_dayTextColor" format="color"/>
-    <attr name="tsquare_titleTextColor" format="color"/>
+    <attr name="tsquare_titleTextStyle" format="reference"/>
     <attr name="tsquare_displayHeader" format="boolean"/>
     <attr name="tsquare_displayDayNamesHeaderRow" format="boolean"/>
     <attr name="tsquare_headerTextColor" format="color"/>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -1,6 +1,8 @@
 <!-- Copyright 2012 Square, Inc. -->
 <resources>
   <dimen name="calendar_day_headers_paddingbottom">4dp</dimen>
+  <dimen name="calendar_month_topmargin">16dp</dimen>
+  <dimen name="calendar_month_title_bottommargin">4dp</dimen>
   <dimen name="calendar_month_title_paddingtop">16dp</dimen>
   <dimen name="calendar_month_title_paddingbottom">4dp</dimen>
   <dimen name="calendar_text_medium">18sp</dimen>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -3,8 +3,6 @@
   <dimen name="calendar_day_headers_paddingbottom">4dp</dimen>
   <dimen name="calendar_month_topmargin">16dp</dimen>
   <dimen name="calendar_month_title_bottommargin">4dp</dimen>
-  <dimen name="calendar_month_title_paddingtop">16dp</dimen>
-  <dimen name="calendar_month_title_paddingbottom">4dp</dimen>
   <dimen name="calendar_text_medium">18sp</dimen>
   <dimen name="calendar_text_small">14sp</dimen>
 </resources>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -1,8 +1,8 @@
 <!-- Copyright 2012 Square, Inc. -->
 <resources>
   <dimen name="calendar_day_headers_paddingbottom">4dp</dimen>
-  <dimen name="calendar_month_topmargin">16dp</dimen>
-  <dimen name="calendar_month_title_bottommargin">4dp</dimen>
+  <dimen name="calendar_month_title_paddingtop">16dp</dimen>
+  <dimen name="calendar_month_title_paddingbottom">4dp</dimen>
   <dimen name="calendar_text_medium">18sp</dimen>
   <dimen name="calendar_text_small">14sp</dimen>
 </resources>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -4,8 +4,8 @@
     <item name="android:textSize">@dimen/calendar_text_medium</item>
     <item name="android:textStyle">bold</item>
     <item name="android:gravity">center_horizontal</item>
-    <item name="android:paddingBottom">@dimen/calendar_month_title_paddingbottom</item>
-    <item name="android:paddingTop">@dimen/calendar_month_title_paddingtop</item>
+    <item name="android:paddingBottom">@dimen/calendar_month_title_bottommargin</item>
+    <item name="android:paddingTop">@dimen/calendar_month_topmargin</item>
   </style>
 
   <style name="CalendarCell">

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -3,6 +3,9 @@
   <style name="CalendarTitle">
     <item name="android:textSize">@dimen/calendar_text_medium</item>
     <item name="android:textStyle">bold</item>
+    <item name="android:gravity">center_horizontal</item>
+    <item name="android:paddingBottom">@dimen/calendar_month_title_paddingbottom</item>
+    <item name="android:paddingTop">@dimen/calendar_month_title_paddingtop</item>
   </style>
 
   <style name="CalendarCell">

--- a/sample/src/main/res/layout/dialog_customized.xml
+++ b/sample/src/main/res/layout/dialog_customized.xml
@@ -15,5 +15,5 @@
     app:tsquare_displayDayNamesHeaderRow="false"
     app:tsquare_dividerColor="@color/transparent"
     app:tsquare_headerTextColor="@color/custom_header_text"
-    app:tsquare_titleTextColor="@color/custom_calendar_text_selector"
+    app:tsquare_titleTextStyle="@style/CustomCalendarTitle"
     />

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -1,0 +1,10 @@
+<!-- Copyright 2012 Square, Inc. -->
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <style name="CustomCalendarTitle">
+    <item name="android:textSize">@dimen/calendar_text_medium</item>
+    <item name="android:gravity">start|left</item>
+    <item name="android:paddingBottom">@dimen/calendar_month_title_paddingbottom</item>
+    <item name="android:paddingTop">@dimen/calendar_month_title_paddingtop</item>
+    <item name="android:color">@color/custom_calendar_text_selector</item>
+  </style>
+</resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -3,8 +3,8 @@
   <style name="CustomCalendarTitle">
     <item name="android:textSize">@dimen/calendar_text_medium</item>
     <item name="android:gravity">start|left</item>
-    <item name="android:paddingBottom">@dimen/calendar_month_title_paddingbottom</item>
-    <item name="android:paddingTop">@dimen/calendar_month_title_paddingtop</item>
+    <item name="android:paddingBottom">@dimen/calendar_month_title_bottommargin</item>
+    <item name="android:paddingTop">@dimen/calendar_month_topmargin</item>
     <item name="android:color">@color/custom_calendar_text_selector</item>
   </style>
 </resources>


### PR DESCRIPTION
## What I did
- Added the possibility to customise the month title from `tsquare_titleTextStyle` attribute (default value, same as before: `@style/CalendarTitle`)
- Removed unnecessary `tsquare_titleTextColor` as we can customise from the style
- Example how to use: `sample/src/main/res/layout/dialog_customized.xml`