### PR TITLE
Adding feature to always show digit dates on any locale

### DIFF
--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -87,6 +87,7 @@ public class CalendarPickerView extends ListView {
   private boolean displayHeader;
   private int headerTextColor;
   private boolean displayDayNamesHeaderRow;
+  private boolean displayAlwaysDigitNumbers;
   private Typeface titleTypeface;
   private Typeface dateTypeface;
 
@@ -131,6 +132,8 @@ public class CalendarPickerView extends ListView {
         res.getColor(R.color.calendar_text_active));
     displayDayNamesHeaderRow =
             a.getBoolean(R.styleable.CalendarPickerView_tsquare_displayDayNamesHeaderRow, true);
+    displayAlwaysDigitNumbers =
+            a.getBoolean(R.styleable.CalendarPickerView_tsquare_displayAlwaysDigitNumbers, false);
     a.recycle();
 
     adapter = new MonthAdapter();
@@ -854,7 +857,8 @@ public class CalendarPickerView extends ListView {
         monthView =
             MonthView.create(parent, inflater, weekdayNameFormat, listener, today, dividerColor,
                 dayBackgroundResId, dayTextColorResId, titleTextStyle, displayHeader,
-                headerTextColor, displayDayNamesHeaderRow, decorators, locale, dayViewAdapter);
+                headerTextColor, displayDayNamesHeaderRow, displayAlwaysDigitNumbers,
+                decorators, locale, dayViewAdapter);
         monthView.setTag(R.id.day_view_adapter_class, dayViewAdapter.getClass());
       } else {
         monthView.setDecorators(decorators);

--- a/library/src/main/java/com/squareup/timessquare/MonthView.java
+++ b/library/src/main/java/com/squareup/timessquare/MonthView.java
@@ -24,21 +24,22 @@ public class MonthView extends LinearLayout {
   private List<CalendarCellDecorator> decorators;
   private boolean isRtl;
   private Locale locale;
+  private boolean alwaysDigitNumbers;
 
   public static MonthView create(ViewGroup parent, LayoutInflater inflater,
       DateFormat weekdayNameFormat, Listener listener, Calendar today, int dividerColor,
       int dayBackgroundResId, int dayTextColorResId, int titleTextStyle, boolean displayHeader,
       int headerTextColor, boolean showDayNamesHeaderRowView, Locale locale,
-      DayViewAdapter adapter) {
+      boolean showAlwaysDigitNumbers, DayViewAdapter adapter) {
     return create(parent, inflater, weekdayNameFormat, listener, today, dividerColor,
         dayBackgroundResId, dayTextColorResId, titleTextStyle, displayHeader, headerTextColor,
-        showDayNamesHeaderRowView, null, locale, adapter);
+        showDayNamesHeaderRowView, showAlwaysDigitNumbers, null, locale, adapter);
   }
 
   public static MonthView create(ViewGroup parent, LayoutInflater inflater,
       DateFormat weekdayNameFormat, Listener listener, Calendar today, int dividerColor,
       int dayBackgroundResId, int dayTextColorResId, int titleTextStyle, boolean displayHeader,
-      int headerTextColor, boolean displayDayNamesHeaderRowView,
+      int headerTextColor, boolean displayDayNamesHeaderRowView, boolean showAlwaysDigitNumbers,
       List<CalendarCellDecorator> decorators, Locale locale, DayViewAdapter adapter) {
     final MonthView view = (MonthView) inflater.inflate(R.layout.month, parent, false);
 
@@ -62,6 +63,7 @@ public class MonthView extends LinearLayout {
 
     view.isRtl = isRtl(locale);
     view.locale = locale;
+    view.alwaysDigitNumbers = showAlwaysDigitNumbers;
     int firstDayOfWeek = today.getFirstDayOfWeek();
     final CalendarRowView headerRow = (CalendarRowView) view.grid.getChildAt(0);
 
@@ -114,7 +116,12 @@ public class MonthView extends LinearLayout {
     Logr.d("Initializing MonthView (%d) for %s", System.identityHashCode(this), month);
     long start = System.currentTimeMillis();
     title.setText(month.getLabel());
-    NumberFormat numberFormatter = NumberFormat.getInstance(locale);
+    NumberFormat numberFormatter;
+      if (alwaysDigitNumbers) {
+      numberFormatter = NumberFormat.getInstance(Locale.US);
+    } else {
+      numberFormatter = NumberFormat.getInstance(locale);
+    }
 
     final int numRows = cells.size();
     grid.setNumRows(numRows);

--- a/library/src/main/java/com/squareup/timessquare/MonthView.java
+++ b/library/src/main/java/com/squareup/timessquare/MonthView.java
@@ -117,7 +117,7 @@ public class MonthView extends LinearLayout {
     long start = System.currentTimeMillis();
     title.setText(month.getLabel());
     NumberFormat numberFormatter;
-      if (alwaysDigitNumbers) {
+    if (alwaysDigitNumbers) {
       numberFormatter = NumberFormat.getInstance(Locale.US);
     } else {
       numberFormatter = NumberFormat.getInstance(locale);

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -8,6 +8,7 @@
     <attr name="tsquare_titleTextStyle" format="reference"/>
     <attr name="tsquare_displayHeader" format="boolean"/>
     <attr name="tsquare_displayDayNamesHeaderRow" format="boolean"/>
+    <attr name="tsquare_displayAlwaysDigitNumbers" format="boolean"/>
     <attr name="tsquare_headerTextColor" format="color"/>
   </declare-styleable>
 

--- a/sample/src/main/java/com/squareup/timessquare/sample/SampleTimesSquareActivity.java
+++ b/sample/src/main/java/com/squareup/timessquare/sample/SampleTimesSquareActivity.java
@@ -63,6 +63,7 @@ public class SampleTimesSquareActivity extends Activity {
     final Button decorator = (Button) findViewById(R.id.button_decorator);
     final Button hebrew = (Button) findViewById(R.id.button_hebrew);
     final Button arabic = (Button) findViewById(R.id.button_arabic);
+    final Button arabicDigits = (Button) findViewById(R.id.button_arabic_with_digits);
     final Button customView = (Button) findViewById(R.id.button_custom_view);
 
     modeButtons.addAll(Arrays.asList(single, multi, range, displayOnly, decorator, customView));
@@ -191,6 +192,14 @@ public class SampleTimesSquareActivity extends Activity {
         dialogView.init(lastYear.getTime(), nextYear.getTime(), new Locale("ar", "EG")) //
             .withSelectedDate(new Date());
       }
+    });
+
+    arabicDigits.setOnClickListener(new OnClickListener() {
+      @Override public void onClick(View view) {
+        showCalendarInDialog("I'm Arabic with Digits!", R.layout.dialog_digits);
+        dialogView.init(lastYear.getTime(), nextYear.getTime(), new Locale("ar", "EG")) //
+           .withSelectedDate(new Date());
+       }
     });
 
     customView.setOnClickListener(new OnClickListener() {

--- a/sample/src/main/res/layout/dialog_digits.xml
+++ b/sample/src/main/res/layout/dialog_digits.xml
@@ -1,0 +1,14 @@
+<com.squareup.timessquare.CalendarPickerView
+    android:id="@+id/calendar_view"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#FFFFFF"
+    android:clipToPadding="false"
+    android:paddingBottom="16dp"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp"
+    android:scrollbarStyle="outsideOverlay"
+    app:tsquare_displayAlwaysDigitNumbers="true"
+    />

--- a/sample/src/main/res/layout/sample_calendar_picker.xml
+++ b/sample/src/main/res/layout/sample_calendar_picker.xml
@@ -90,6 +90,13 @@
           />
 
       <Button
+          android:id="@+id/button_arabic_with_digits"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/ArabicDigits"
+          />
+
+      <Button
           android:id="@+id/button_custom_view"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="Decorator">Decorator</string>
     <string name="Hebrew">Hebrew</string>
     <string name="Arabic">Arabic</string>
+    <string name="ArabicDigits">Arabic with Digits</string>
     <string name="CustomView">Custom View</string>
     <string name="Dialog">Dialog</string>
     <string name="DisplayOnly">DisplayOnly</string>


### PR DESCRIPTION
Basically just added an XML attribute called

**tsquare_displayAlwaysDigitNumbers** (that has a default value of false)

which allows the library to always show digit numbers on any locale.

The sample was updated to show this behavior and this is the result:
(Please ignore the green circle)

![](https://cldup.com/QwoU_pLygj.png)

The arabic calendar keeps working as usual:

![](https://cldup.com/TKACvzz6NW.png)