### PR TITLE
Fix month name format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ allprojects {
 }
 
 ext {
-  minSdkVersion = 8
+  minSdkVersion = 9
   targetSdkVersion = 25
   compileSdkVersion = 25
   buildToolsVersion = '25.0.2'

--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -244,8 +244,8 @@ public class CalendarPickerView extends ListView {
         && monthCounter.get(YEAR) < maxYear + 1) { // But not > next yr.
       Date date = monthCounter.getTime();
       MonthDescriptor month =
-          new MonthDescriptor(monthCounter.get(MONTH), monthCounter.get(YEAR), date,
-                  formatMonthDate(date, locale, timeZone));
+          new MonthDescriptor(monthCounter.get(MONTH), monthCounter.get(YEAR),
+                  date, formatMonthDate(date, locale, timeZone));
       cells.put(monthKey(month), getMonthCells(month, monthCounter));
       Logr.d("Adding month %s", month);
       months.add(month);
@@ -632,7 +632,8 @@ public class CalendarPickerView extends ListView {
    */
   private String formatMonthDate(Date date, Locale locale, TimeZone timeZone) {
     if (android.os.Build.VERSION.SDK_INT > Build.VERSION_CODES.FROYO) {
-      int flags = DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_YEAR | DateUtils.FORMAT_NO_MONTH_DAY;
+      int flags = DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_YEAR
+              | DateUtils.FORMAT_NO_MONTH_DAY;
       Formatter formatter = new Formatter(new StringBuilder(50), locale);
       return DateUtils.formatDateRange(getContext(), formatter, date.getTime(), date.getTime(),
               flags, timeZone.getID()).toString();

--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -6,6 +6,8 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Typeface;
+import android.os.Build;
+import android.text.format.DateUtils;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -21,6 +23,7 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Formatter;
 import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -619,6 +622,22 @@ public class CalendarPickerView extends ListView {
       scrollToSelectedMonth(monthCellWithMonthIndex.monthIndex, smoothScroll);
     }
     return wasSelected;
+  }
+
+  /**
+   * Use {@link DateUtils} to format the dates. If the version is lower than API 9, we will format
+   * using the old way, that means, SimpleDateFormat.
+   *
+   * @see DateUtils
+   */
+  private String formatMonthDate(Date date, Locale locale, TimeZone timeZone) {
+    if (android.os.Build.VERSION.SDK_INT > Build.VERSION_CODES.FROYO) {
+      int flags = DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_NO_MONTH_DAY;
+      Formatter formatter = new Formatter(new StringBuilder(50), locale);
+      return DateUtils.formatDateRange(getContext(), formatter, date.getTime(), date.getTime(),
+              flags, timeZone.getID()).toString();
+    }
+    return monthNameFormat.format(date);
   }
 
   private void validateDate(Date date) {

--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -207,7 +207,7 @@ public class CalendarPickerView extends ListView {
         new SimpleDateFormat(getContext().getString(R.string.month_name_format), locale);
     monthNameFormat.setTimeZone(timeZone);
     for (MonthDescriptor month : months) {
-      month.setLabel(monthNameFormat.format(month.getDate()));
+      month.setLabel(formatMonthDate(month.getDate(), locale, timeZone));
     }
     weekdayNameFormat =
         new SimpleDateFormat(getContext().getString(R.string.day_name_format), locale);
@@ -245,7 +245,7 @@ public class CalendarPickerView extends ListView {
       Date date = monthCounter.getTime();
       MonthDescriptor month =
           new MonthDescriptor(monthCounter.get(MONTH), monthCounter.get(YEAR), date,
-              monthNameFormat.format(date));
+                  formatMonthDate(date, locale, timeZone));
       cells.put(monthKey(month), getMonthCells(month, monthCounter));
       Logr.d("Adding month %s", month);
       months.add(month);
@@ -632,7 +632,7 @@ public class CalendarPickerView extends ListView {
    */
   private String formatMonthDate(Date date, Locale locale, TimeZone timeZone) {
     if (android.os.Build.VERSION.SDK_INT > Build.VERSION_CODES.FROYO) {
-      int flags = DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_NO_MONTH_DAY;
+      int flags = DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_YEAR | DateUtils.FORMAT_NO_MONTH_DAY;
       Formatter formatter = new Formatter(new StringBuilder(50), locale);
       return DateUtils.formatDateRange(getContext(), formatter, date.getTime(), date.getTime(),
               flags, timeZone.getID()).toString();

--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -22,6 +22,7 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Formatter;
 import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -100,6 +101,9 @@ public class CalendarPickerView extends ListView {
 
   private boolean monthsReverseOrder;
 
+  private StringBuilder monthBuilder = new StringBuilder(50);
+  private Formatter monthFormatter;
+
   public void setDecorators(List<CalendarCellDecorator> decorators) {
     this.decorators = decorators;
     if (null != adapter) {
@@ -148,6 +152,7 @@ public class CalendarPickerView extends ListView {
     weekdayNameFormat.setTimeZone(timeZone);
     fullDateFormat = DateFormat.getDateInstance(DateFormat.MEDIUM, locale);
     fullDateFormat.setTimeZone(timeZone);
+    monthFormatter = new Formatter(monthBuilder, locale);
 
     if (isInEditMode()) {
       Calendar nextYear = Calendar.getInstance(timeZone, locale);
@@ -206,6 +211,7 @@ public class CalendarPickerView extends ListView {
     weekdayNameFormat.setTimeZone(timeZone);
     fullDateFormat = DateFormat.getDateInstance(DateFormat.MEDIUM, locale);
     fullDateFormat.setTimeZone(timeZone);
+    monthFormatter = new Formatter(monthBuilder, locale);
 
     this.selectionMode = SelectionMode.SINGLE;
     // Clear out any previously-selected dates/cells.
@@ -625,26 +631,28 @@ public class CalendarPickerView extends ListView {
     int flags = DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_YEAR
             | DateUtils.FORMAT_NO_MONTH_DAY;
 
-    // Save default Locale/Timezone
+    // Save default Locale
     Locale defaultLocale = Locale.getDefault();
-    TimeZone defaultTimezone = TimeZone.getDefault();
 
-    // Set new default Locale/Timezone, the reason to do that is DateUtils.formatDateTime uses
+    // Set new default Locale, the reason to do that is DateUtils.formatDateTime uses
     // internally this method DateIntervalFormat.formatDateRange to format the date. And this
-    // method uses the default locale/timezone.
+    // method uses the default locale.
     //
     // More details about the methods:
     // - DateUtils.formatDateTime: https://goo.gl/3YW52Q
     // - DateIntervalFormat.formatDateRange: https://goo.gl/RRmfK7
     Locale.setDefault(locale);
-    TimeZone.setDefault(timeZone);
 
     // Format date using the new locale and timezone
-    String formattedDate = DateUtils.formatDateTime(getContext(), date.getTime(), flags);
+    String formattedDate = DateUtils.formatDateRange(getContext(), monthFormatter, date.getTime(),
+            date.getTime(), flags, timeZone.getID()).toString();
+
+    // Call setLength(0) on StringBuilder passed to the Formatter constructor to not accumulate
+    // the results
+    monthBuilder.setLength(0);
 
     // Restore default Locale/Timezone to avoid generating any side effects
     Locale.setDefault(defaultLocale);
-    TimeZone.setDefault(defaultTimezone);
 
     return formattedDate;
   }

--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Typeface;
-import android.os.Build;
 import android.text.format.DateUtils;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -74,7 +73,6 @@ public class CalendarPickerView extends ListView {
   final List<Calendar> highlightedCals = new ArrayList<>();
   private Locale locale;
   private TimeZone timeZone;
-  private DateFormat monthNameFormat;
   private DateFormat weekdayNameFormat;
   private DateFormat fullDateFormat;
   private Calendar minCal;
@@ -147,8 +145,6 @@ public class CalendarPickerView extends ListView {
     minCal = Calendar.getInstance(timeZone, locale);
     maxCal = Calendar.getInstance(timeZone, locale);
     monthCounter = Calendar.getInstance(timeZone, locale);
-    monthNameFormat = new SimpleDateFormat(context.getString(R.string.month_name_format), locale);
-    monthNameFormat.setTimeZone(timeZone);
     weekdayNameFormat = new SimpleDateFormat(context.getString(R.string.day_name_format), locale);
     weekdayNameFormat.setTimeZone(timeZone);
     fullDateFormat = DateFormat.getDateInstance(DateFormat.MEDIUM, locale);
@@ -203,9 +199,6 @@ public class CalendarPickerView extends ListView {
     minCal = Calendar.getInstance(timeZone, locale);
     maxCal = Calendar.getInstance(timeZone, locale);
     monthCounter = Calendar.getInstance(timeZone, locale);
-    monthNameFormat =
-        new SimpleDateFormat(getContext().getString(R.string.month_name_format), locale);
-    monthNameFormat.setTimeZone(timeZone);
     for (MonthDescriptor month : months) {
       month.setLabel(formatMonthDate(month.getDate(), locale, timeZone));
     }
@@ -625,20 +618,16 @@ public class CalendarPickerView extends ListView {
   }
 
   /**
-   * Use {@link DateUtils} to format the dates. If the version is lower than API 9, we will format
-   * using the old way, that means, SimpleDateFormat.
+   * Use {@link DateUtils} to format the dates.
    *
    * @see DateUtils
    */
   private String formatMonthDate(Date date, Locale locale, TimeZone timeZone) {
-    if (android.os.Build.VERSION.SDK_INT > Build.VERSION_CODES.FROYO) {
-      int flags = DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_YEAR
-              | DateUtils.FORMAT_NO_MONTH_DAY;
-      Formatter formatter = new Formatter(new StringBuilder(50), locale);
-      return DateUtils.formatDateRange(getContext(), formatter, date.getTime(), date.getTime(),
-              flags, timeZone.getID()).toString();
-    }
-    return monthNameFormat.format(date);
+    int flags = DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_YEAR
+            | DateUtils.FORMAT_NO_MONTH_DAY;
+    Formatter formatter = new Formatter(new StringBuilder(50), locale);
+    return DateUtils.formatDateRange(getContext(), formatter, date.getTime(), date.getTime(),
+            flags, timeZone.getID()).toString();
   }
 
   private void validateDate(Date date) {

--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -101,7 +101,7 @@ public class CalendarPickerView extends ListView {
 
   private boolean monthsReverseOrder;
 
-  private StringBuilder monthBuilder = new StringBuilder(50);
+  private final StringBuilder monthBuilder = new StringBuilder(50);
   private Formatter monthFormatter;
 
   public void setDecorators(List<CalendarCellDecorator> decorators) {
@@ -152,7 +152,6 @@ public class CalendarPickerView extends ListView {
     weekdayNameFormat.setTimeZone(timeZone);
     fullDateFormat = DateFormat.getDateInstance(DateFormat.MEDIUM, locale);
     fullDateFormat.setTimeZone(timeZone);
-    monthFormatter = new Formatter(monthBuilder, locale);
 
     if (isInEditMode()) {
       Calendar nextYear = Calendar.getInstance(timeZone, locale);

--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -643,7 +643,7 @@ public class CalendarPickerView extends ListView {
     // - DateIntervalFormat.formatDateRange: https://goo.gl/RRmfK7
     Locale.setDefault(locale);
 
-    // Format date using the new locale and timezone
+    // Format date using the new Locale
     String formattedDate = DateUtils.formatDateRange(getContext(), monthFormatter, date.getTime(),
             date.getTime(), flags, timeZone.getID()).toString();
 
@@ -651,7 +651,7 @@ public class CalendarPickerView extends ListView {
     // the results
     monthBuilder.setLength(0);
 
-    // Restore default Locale/Timezone to avoid generating any side effects
+    // Restore default Locale to avoid generating any side effects
     Locale.setDefault(defaultLocale);
 
     return formattedDate;


### PR DESCRIPTION
## Issue
For some languages like Japanese or Chinese, the format for month title should be `yyyy MMMM` instead of  `MMMM yyyy`.

**References:**
Japan: https://en.wikipedia.org/wiki/Date_and_time_notation_in_Japan
Other countries: https://en.wikipedia.org/wiki/Date_format_by_country

## Fix
Basically, I fixed this issue using [DateUtils](https://developer.android.com/reference/android/text/format/DateUtils.html). I set `Timezone` using [DateUtils.formatDateRange(...)](https://goo.gl/r5buh9) and `Locale` using [Formatter](https://developer.android.com/reference/java/util/Formatter.html) like this native code from Google:

```
1062    public static String formatDateRange(Context context, long startMillis,
1063            long endMillis, int flags) {
1064        Formatter f = new Formatter(new StringBuilder(50), Locale.getDefault());
1065        return formatDateRange(context, f, startMillis, endMillis, flags).toString();
1066    }
```
References: http://grepcode.com/file/repository.grepcode.com/java/ext/com.google.android/android/2.0_r1/android/text/format/DateUtils.java#1061

## Screenshot
For the Japanese language:

![japanese](https://user-images.githubusercontent.com/1906734/33496220-af48c9dc-d6c9-11e7-8f7e-03bdc6e35d1d.png)

**Without the fix, we can see that the format is wrong and it should be "YYYY年MM月"**

For the English language:

![english](https://user-images.githubusercontent.com/1906734/33496256-d14af938-d6c9-11e7-9d11-83ff16d27786.png)

**Month title didn't change it as expected for the English language**

## Improvement
With this fix, we don't need `month_name_format` string. Then it is not necessary to translate this string for each language. 😄 