### PR TITLE
Missing digits on displayAlwaysDigitNumbers feature 

### DIFF
--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -18,6 +18,7 @@ import java.text.DateFormat;
 import java.text.DateFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
@@ -61,6 +62,10 @@ public class CalendarPickerView extends ListView {
      */
     RANGE
   }
+
+  // List of that require manually creation of YYYY MMMM date format
+  private static final ArrayList<String> manuallyHandledLocalesLanguages =
+          new ArrayList<>(Arrays.asList("ar", "my"));
 
   private final CalendarPickerView.MonthAdapter adapter;
   private final IndexedLinkedHashMap<String, List<List<MonthCellDescriptor>>> cells =
@@ -645,10 +650,21 @@ public class CalendarPickerView extends ListView {
     // - DateIntervalFormat.formatDateRange: https://goo.gl/RRmfK7
     Locale.setDefault(locale);
 
-    // Format date using the new Locale
-    String formattedDate = DateUtils.formatDateRange(getContext(), monthFormatter, date.getTime(),
-            date.getTime(), flags, timeZone.getID()).toString();
-
+    String dateFormatted;
+    if (displayAlwaysDigitNumbers
+      && manuallyHandledLocalesLanguages.contains(locale.getLanguage())) {
+      StringBuilder sb = new StringBuilder();
+      SimpleDateFormat sdfMonth = new SimpleDateFormat(getContext()
+        .getString(R.string.month_only_name_format), locale);
+      SimpleDateFormat sdfYear = new SimpleDateFormat(getContext()
+        .getString(R.string.year_only_format), Locale.ENGLISH);
+      dateFormatted = sb.append(sdfMonth.format(date.getTime())).append(" ")
+        .append(sdfYear.format(date.getTime())).toString();
+    } else {
+      // Format date using the new Locale
+      dateFormatted = DateUtils.formatDateRange(getContext(), monthFormatter,
+        date.getTime(), date.getTime(), flags, timeZone.getID()).toString();
+    }
     // Call setLength(0) on StringBuilder passed to the Formatter constructor to not accumulate
     // the results
     monthBuilder.setLength(0);
@@ -656,7 +672,7 @@ public class CalendarPickerView extends ListView {
     // Restore default Locale to avoid generating any side effects
     Locale.setDefault(defaultLocale);
 
-    return formattedDate;
+    return dateFormatted;
   }
 
   private void validateDate(Date date) {

--- a/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarPickerView.java
@@ -63,9 +63,9 @@ public class CalendarPickerView extends ListView {
     RANGE
   }
 
-  // List of that require manually creation of YYYY MMMM date format
-  private static final ArrayList<String> manuallyHandledLocalesLanguages =
-          new ArrayList<>(Arrays.asList("ar", "my"));
+  // List of languages that require manually creation of YYYY MMMM date format
+  private static final ArrayList<String> explicitlyNumericYearLocaleLanguages =
+      new ArrayList<>(Arrays.asList("ar", "my"));
 
   private final CalendarPickerView.MonthAdapter adapter;
   private final IndexedLinkedHashMap<String, List<List<MonthCellDescriptor>>> cells =
@@ -652,7 +652,7 @@ public class CalendarPickerView extends ListView {
 
     String dateFormatted;
     if (displayAlwaysDigitNumbers
-      && manuallyHandledLocalesLanguages.contains(locale.getLanguage())) {
+      && explicitlyNumericYearLocaleLanguages.contains(locale.getLanguage())) {
       StringBuilder sb = new StringBuilder();
       SimpleDateFormat sdfMonth = new SimpleDateFormat(getContext()
         .getString(R.string.month_only_name_format), locale);

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -5,4 +5,6 @@
   <string name="day_name_format">EEE</string>
   <string name="invalid_date">Date must be between %1$s and %2$s.</string>
   <string name="month_name_format">MMMM yyyy</string>
+  <string name="month_only_name_format">MMMM</string>
+  <string name="year_only_format">yyyy</string>
 </resources>


### PR DESCRIPTION
From the feature on the xml to be able to show digits regardless of the locale, the digits on the months for the year were missing. This pull request fixes that.

Basically we looked for some languages where the years are expressed as non western arabic digit numbers in their language as well, so those are particularly selected manually when this flag is on. We could call this a "whitelist". 

In the current "whitelist", the languages included are:

- **Burmese**
- **Arabic**

As according to this post (https://stackoverflow.com/questions/7973023/what-is-the-list-of-supported-languages-locales-on-android) those are some of the supported languages that have this particularity. It would be awesome if the community could help out more on this as, there are too many languages out there. 🌮 

NOTE: languages in the whitelist will always have the format **month** + **year** (or the other way around due to RTL)

Some Images:

**Burmese language (LTR) used in the Arabic Dialog for testing**

<img width="317" alt="" src="https://user-images.githubusercontent.com/6641413/33723153-265bb268-db6c-11e7-85be-0917bd735a8e.png">

**Arabic language (RTL)**

<img width="340" alt="" src="https://user-images.githubusercontent.com/6641413/33763189-cdf72536-dc0f-11e7-8bc7-119c89623e07.png">

