### PR TITLE
Fix - Support Theme Attributes For tsquare_dayTextColor (fixes #509)

### DIFF
--- a/library/src/main/java/com/squareup/timessquare/CalendarGridView.java
+++ b/library/src/main/java/com/squareup/timessquare/CalendarGridView.java
@@ -10,6 +10,8 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
 
+import static android.os.Build.VERSION;
+import static android.os.Build.VERSION_CODES;
 import static android.view.View.MeasureSpec.AT_MOST;
 import static android.view.View.MeasureSpec.EXACTLY;
 import static android.view.View.MeasureSpec.makeMeasureSpec;
@@ -52,7 +54,12 @@ public class CalendarGridView extends ViewGroup {
 
   public void setDayTextColor(int resId) {
     for (int i = 0; i < getChildCount(); i++) {
-      ColorStateList colors = getResources().getColorStateList(resId);
+      ColorStateList colors;
+      if (VERSION.SDK_INT >= VERSION_CODES.M) {
+        colors = getContext().getColorStateList(resId);
+      } else {
+        colors = getResources().getColorStateList(resId);
+      }
       ((CalendarRowView) getChildAt(i)).setCellTextColor(colors);
     }
   }

--- a/sample/src/main/res/color/custom_calendar_text_selector.xml
+++ b/sample/src/main/res/color/custom_calendar_text_selector.xml
@@ -3,10 +3,10 @@
 
 <selector xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:app="http://schemas.android.com/apk/res-auto">
-    <item android:state_selected="true" android:color="@color/custom_text_selected"/>
-    <item android:state_pressed="true" android:color="@color/custom_text_selected"/>
-    <item app:tsquare_state_current_month="false" android:color="@color/custom_text_inactive"/>
-    <item app:tsquare_state_today="true" android:color="@color/custom_text_selected"/>
-    <item app:tsquare_state_selectable="false" android:color="@color/custom_text_inactive" />
-    <item android:color="@color/custom_background_today"/>
+    <item android:state_selected="true" android:color="?textSelected"/>
+    <item android:state_pressed="true" android:color="?textSelected"/>
+    <item app:tsquare_state_current_month="false" android:color="?textDisabled"/>
+    <item app:tsquare_state_today="true" android:color="?textSelected"/>
+    <item app:tsquare_state_selectable="false" android:color="?textDisabled" />
+    <item android:color="?textDefault"/>
 </selector>

--- a/sample/src/main/res/layout/dialog_customized.xml
+++ b/sample/src/main/res/layout/dialog_customized.xml
@@ -1,19 +1,18 @@
-<com.squareup.timessquare.CalendarPickerView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<com.squareup.timessquare.CalendarPickerView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/calendar_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/custom_background"
     android:clipToPadding="false"
-    android:paddingBottom="16dp"
     android:paddingLeft="16dp"
     android:paddingRight="16dp"
+    android:paddingBottom="16dp"
     android:scrollbarStyle="outsideOverlay"
+    android:theme="@style/MyTheme"
     app:tsquare_dayBackground="@drawable/custom_calendar_bg_selector"
     app:tsquare_dayTextColor="@color/custom_calendar_text_selector"
     app:tsquare_displayDayNamesHeaderRow="false"
     app:tsquare_dividerColor="@color/transparent"
     app:tsquare_headerTextColor="@color/custom_header_text"
-    app:tsquare_titleTextStyle="@style/CustomCalendarTitle"
-    />
+    app:tsquare_titleTextStyle="@style/CustomCalendarTitle" />

--- a/sample/src/main/res/values-night/themes.xml
+++ b/sample/src/main/res/values-night/themes.xml
@@ -1,0 +1,11 @@
+<!-- Copyright 2012 Square, Inc. -->
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <style name="MyTheme">
+
+        <item name="textDefault">#FFFFFF</item>
+        <item name="textDisabled">#AAAAAA</item>
+        <item name="textSelected">#FFFFFF</item>
+
+    </style>
+</resources>

--- a/sample/src/main/res/values-night/themes.xml
+++ b/sample/src/main/res/values-night/themes.xml
@@ -3,9 +3,9 @@
 
     <style name="MyTheme">
 
-        <item name="textDefault">#FFFFFF</item>
-        <item name="textDisabled">#AAAAAA</item>
-        <item name="textSelected">#FFFFFF</item>
+        <item name="textDefault">@color/custom_background_today</item>
+        <item name="textDisabled">@color/custom_text_inactive</item>
+        <item name="textSelected">@color/custom_text_selected</item>
 
     </style>
 </resources>

--- a/sample/src/main/res/values/attrs.xml
+++ b/sample/src/main/res/values/attrs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <attr name="textDefault" format="color" />
+    <attr name="textDisabled" format="color" />
+    <attr name="textSelected" format="color" />
+</resources>

--- a/sample/src/main/res/values/themes.xml
+++ b/sample/src/main/res/values/themes.xml
@@ -1,0 +1,11 @@
+<!-- Copyright 2012 Square, Inc. -->
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <style name="MyTheme">
+
+        <item name="textDefault">#000000</item>
+        <item name="textDisabled">#CCCCCC</item>
+        <item name="textSelected">#FFFFFFFF</item>
+
+    </style>
+</resources>

--- a/sample/src/main/res/values/themes.xml
+++ b/sample/src/main/res/values/themes.xml
@@ -3,9 +3,9 @@
 
     <style name="MyTheme">
 
-        <item name="textDefault">#000000</item>
-        <item name="textDisabled">#CCCCCC</item>
-        <item name="textSelected">#FFFFFFFF</item>
+        <item name="textDefault">@color/custom_background_today</item>
+        <item name="textDisabled">@color/custom_text_inactive</item>
+        <item name="textSelected">@color/custom_text_selected</item>
 
     </style>
 </resources>


### PR DESCRIPTION
## Work done

Implement support for theme attributes used in selectors for `app:tsquare_dayTextColor`.

```
    app:tsquare_dayTextColor="@color/custom_calendar_text_selector"
```
with custom_calendar_text_selector.xml
```
<selector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
    <item android:color="?textSelected" android:state_selected="true" />
    <item android:color="?textSelected" android:state_pressed="true" />
    <item android:color="?textDisabled" app:tsquare_state_selectable="true" />
    <item android:color="?textDefault" />
</selector>

```

Fixes #509

![image](https://user-images.githubusercontent.com/9137576/149571090-c8e326cc-e0ee-4fa9-bace-a2ec76847061.png)

I did not provide an example with selector and custom attributes, but happy to do if necessary, [like on this branch](https://github.com/quentin41500/android-times-square/commit/f17075f65cd34763cfb70d278155b6bb98686a95).